### PR TITLE
fix(array): recover binary vector data from a text-JSON round-trip

### DIFF
--- a/Meta/src/ext/array/array.cpp
+++ b/Meta/src/ext/array/array.cpp
@@ -41,6 +41,20 @@ void Array::json_from(nlohmann::json const &json)
     {
       vector = v.get<std::vector<float>>();
     }
+    else if (v.is_object() && v.contains("bytes") && v["bytes"].is_array())
+    {
+      // nlohmann's binary type only round-trips through binary formats (CBOR,
+      // MessagePack, BSON). Written with dump() and re-read with parse() — what
+      // any text .json container does — it degenerates into
+      // {"bytes": [...], "subtype": ...}. Accept that form so text round-trips
+      // keep their data, and so files already written this way stay readable.
+      auto const bytes = v["bytes"].get<std::vector<uint8_t>>();
+      if (bytes.size() % sizeof(float) == 0)
+      {
+        vector.resize(bytes.size() / sizeof(float));
+        std::memcpy(vector.data(), bytes.data(), bytes.size());
+      }
+    }
   }
 
   size_t const expected_size = static_cast<size_t>(std::max(0, shape.x)) *

--- a/tests/test_meta/main.cpp
+++ b/tests/test_meta/main.cpp
@@ -320,6 +320,25 @@ int main()
 
     std::cout << "[array] binary round-trip OK" << std::endl;
 
+    // Text round-trip. nlohmann's binary type only survives binary formats;
+    // through dump()/parse() it degenerates into {"bytes": [...], "subtype": ...}.
+    // Hosts persisting to a text .json file take this path, so the reader has to
+    // recover the data from that form too.
+    {
+      auto const j_text = nlohmann::json::parse(c.json_to().dump());
+      assert(!j_text["arr"]["value"]["vector"].is_binary());
+
+      meta::AttributeContainer c3;
+      c3.json_from(j_text);
+      auto const &decoded_text = c3.value<meta::Array>("arr");
+      assert(decoded_text.shape.x == 3 && decoded_text.shape.y == 2);
+      assert(decoded_text.vector.size() == 6);
+      assert(decoded_text.vector[2] == 30.f);
+      assert(decoded_text.vector[5] == 60.f);
+
+      std::cout << "[array] text (dump/parse) round-trip OK" << std::endl;
+    }
+
     // Test size incompatibility warning and zero-filling
     nlohmann::json bad_arr_json = {
         {"shape", {{"x", 3}, {"y", 2}}},


### PR DESCRIPTION
Fixes #26.

`Array::json_to` writes the vector as `nlohmann::json::binary`, which only round-trips through binary formats (CBOR, MessagePack, BSON). Through `dump()`/`parse()` — what any host persisting to a text `.json` file does — it degenerates into `{"bytes": [...], "subtype": ...}`.

`json_from` tested only `is_binary()` and `is_array()`, so neither branch matched, the vector stayed empty, and the trailing size check padded it back to `shape.x * shape.y` zeros. The array came back correctly sized and completely blank, with a single warning as the only trace:

```
[meta--] Array size mismatch: shape (512x512) expects 262144 elements, but data has 0 elements.
```

In Hesiod (`utils.cpp:197` → `dump(4)`) that means every painted `Brush` node is lost on reload.

This accepts the degenerate object form as a third branch in `json_from`. Since the bytes are already present in files written this way, it **recovers existing projects** rather than only fixing future saves — which is why the fix belongs on the reader even if `json_to` is later changed to emit base64 or a plain float array.

### Testing

Added a text round-trip case to `tests/test_meta`. The existing `[array] binary round-trip` test fed `json_to()`'s output straight back into `json_from()` without ever leaving nlohmann's object model, so the binary value never degenerated — which is why this went unnoticed. The new test goes through `dump()`/`parse()`.

Verified it actually discriminates: with the `array.cpp` change reverted the suite aborts on the assert (exit 134); with it, the full suite passes (exit 0).

Also confirmed end-to-end in Hesiod: paint a Brush → save → reload now restores the painted data.

### Worth knowing separately

**The test suite's assertions are compiled out in Release builds.** `tests/test_meta` is built entirely from `assert()`, so with `-DCMAKE_BUILD_TYPE=Release` (which defines `NDEBUG`) every check becomes a no-op and the suite prints all its "OK" lines and exits 0 regardless of what is broken — I hit exactly that while verifying this fix, and had to switch to a Debug build to see the failure. Worth either forcing `-UNDEBUG` for the test target or moving to a check macro that survives Release. Happy to file or send a patch if useful.
