### PR TITLE
fix(factory): self-register built-in types on first factory use

### DIFF
--- a/Meta/include/meta/serialization/attribute_factory.hpp
+++ b/Meta/include/meta/serialization/attribute_factory.hpp
@@ -100,7 +100,8 @@ template <typename T> void register_attribute_type(const std::string &name)
 /**
  * @brief Register all built-in attribute types.
  *
- * Typically called once at application startup or before deserialization.
+ * Invoked automatically on first use of AttributeFactory::create(); hosts do
+ * not need to call it. Calling it manually remains safe.
  */
 void register_builtin_types();
 

--- a/Meta/src/attribute_factory.cpp
+++ b/Meta/src/attribute_factory.cpp
@@ -1,6 +1,8 @@
 /* Copyright (c) 2026 Otto Link. Distributed under the terms of the GNU General
    Public License. The full license is in the file LICENSE, distributed with
    this software. */
+#include <mutex>
+
 #include "meta/serialization/attribute_factory.hpp"
 #include "meta/core/abstract_attribute.hpp"
 #include "meta/core/attribute_container.hpp"
@@ -21,6 +23,13 @@ std::unique_ptr<AbstractAttribute> AttributeFactory::create(
     const std::string &name,
     const std::string &attr_name) const
 {
+  // Hosts cannot be relied upon to call register_builtin_types() at startup;
+  // populate the registry before the first lookup. This lives here rather
+  // than in instance() because register_builtin_types() itself calls
+  // instance() and would recurse.
+  static std::once_flag builtin_types_once;
+  std::call_once(builtin_types_once, register_builtin_types);
+
   Logger::log()->trace("AttributeFactory::create: type='{}', name='{}'",
                        name,
                        attr_name);

--- a/tests/test_meta/main.cpp
+++ b/tests/test_meta/main.cpp
@@ -1,3 +1,4 @@
+#include <cassert>
 #include <iostream>
 
 #include "meta.hpp"
@@ -45,6 +46,27 @@ META_DEFINE_TYPE_NAME(Vec2);
 int main()
 {
   using namespace meta;
+
+  // ---------------------------------------------------------------------------
+  // Factory self-registration (issue #22)
+  // ---------------------------------------------------------------------------
+
+  // Must run before anything in this process registers types manually: a host
+  // that never calls register_builtin_types() still needs the factory to
+  // reconstruct undeclared attributes from their serialized "type" field.
+  {
+    AttributeContainer src;
+    src.add("lazy_float", 0.25f);
+    src.add("lazy_string", std::string("abc"));
+
+    AttributeContainer dst; // declares nothing, registers nothing
+    dst.json_from(src.json_to());
+
+    const float *f = dst.try_value<float>("lazy_float");
+    assert(f && *f == 0.25f);
+    const std::string *s = dst.try_value<std::string>("lazy_string");
+    assert(s && *s == "abc");
+  }
 
   AttributeContainer container;
 


### PR DESCRIPTION
Fixes #22.

`register_builtin_types()` is invoked in exactly one place in the tree — the test suite — so `AttributeFactory`'s registry is empty in any real host and the factory fallback in `AttributeContainer::json_from` (the whole point of the serialized `"type"` field) is inert. In Hesiod this surfaces as dozens of error lines per loaded file:

```
[meta--] [---E---] json_from: unknown attribute type 'std::string' for 'compat.legacy_type'
[meta--] [---E---] json_from: unknown attribute type 'bool' for 'ui.state'
```

This takes option 1 from the issue: `register_builtin_types()` now runs via `std::call_once` on the first `AttributeFactory::create()`, so no host can forget it and no API changes. It lives in `create()` rather than `instance()` deliberately — `register_builtin_types()` itself calls `instance()`, which would recurse into the static-local initialisation.

Calling `register_builtin_types()` manually remains safe; the container round-trip later in the test suite exercises exactly that (manual registration followed by factory use).

**Test**: a new assert block at the top of `test_meta`'s `main()` — before anything in the process registers types manually — deserializes a container from scratch and requires the undeclared attributes to be reconstructed. It aborts without the fix (`Assertion 'f && *f == 0.25f' failed`, after logging exactly the `unknown attribute type 'std::string'` error above) and passes with it; verified both ways on a Debug build (the suite's asserts are compiled out under NDEBUG).

**One consequence worth an explicit decision** (flagged in the issue): with the factory live, stale `compat.legacy_type` / `ui.*` metadata entries in existing files now materialise as real attributes on load instead of being discarded with an error. Nothing depends on them today, but if they're meant to be retired that probably wants doing explicitly rather than as a side effect of this fix.
