### PR TITLE
fix(qt): RangeBar histogram shares the handle mapping and is no longer overpainted

### DIFF
--- a/MetaUI/qt/include/meta_qt/widget_renderer_inl/glm_vec2.inl
+++ b/MetaUI/qt/include/meta_qt/widget_renderer_inl/glm_vec2.inl
@@ -263,9 +263,12 @@ template <> struct WidgetRenderer<glm::vec2>
         try
         {
           auto data = range_provider();
+          // An empty result is forwarded too: the bar shows a "no data" hint
+          // instead of drawing nothing.
           if (auto histogram = data.get<HistogramData>())
-            if (!histogram->y.empty())
-              bar->set_histogram(histogram->x, histogram->y);
+            bar->set_histogram(histogram->x, histogram->y);
+          else
+            bar->set_histogram({}, {});
         }
         catch (...)
         {
@@ -338,8 +341,9 @@ template <> struct WidgetRenderer<glm::vec2>
               {
                 auto data = range_provider();
                 if (auto histogram = data.get<HistogramData>())
-                  if (!histogram->y.empty())
-                    bar->set_histogram(histogram->x, histogram->y);
+                  bar->set_histogram(histogram->x, histogram->y);
+                else
+                  bar->set_histogram({}, {});
               }
               catch (...)
               {

--- a/MetaUI/qt/include/meta_qt/widgets/range_bar.hpp
+++ b/MetaUI/qt/include/meta_qt/widgets/range_bar.hpp
@@ -74,6 +74,7 @@ private:
 
   std::vector<float> hist_x_;
   std::vector<float> hist_y_;
+  bool               hist_provided_ = false; // set_histogram was called
 
   static constexpr int pad_h_ = 10;   // horizontal padding (handle overhang)
   static constexpr int pad_v_ = 8;    // vertical padding

--- a/MetaUI/qt/src/widgets/range_bar.cpp
+++ b/MetaUI/qt/src/widgets/range_bar.cpp
@@ -160,30 +160,6 @@ void RangeBar::mouseReleaseEvent(QMouseEvent *e)
 
 void RangeBar::paintEvent(QPaintEvent *)
 {
-  // Draw histogram if present
-  if (!this->hist_y_.empty())
-  {
-    QPainter painter(this);
-    painter.setRenderHint(QPainter::Antialiasing, false);
-    const QRect r = this->rect();
-    const float ymax = *std::max_element(this->hist_y_.begin(),
-                                         this->hist_y_.end());
-    if (ymax > 0.f)
-    {
-      const int   n = static_cast<int>(this->hist_y_.size());
-      const float bw = static_cast<float>(r.width()) / static_cast<float>(n);
-      QColor      c = this->palette().color(QPalette::Mid);
-      c.setAlpha(90);
-      painter.setPen(Qt::NoPen);
-      painter.setBrush(c);
-      for (int i = 0; i < n; ++i)
-      {
-        const float h = (this->hist_y_[i] / ymax) * r.height();
-        painter.drawRect(QRectF(r.left() + i * bw, r.bottom() - h, bw, h));
-      }
-    }
-  }
-
   QPainter p(this);
   p.setRenderHint(QPainter::Antialiasing);
 
@@ -204,16 +180,98 @@ void RangeBar::paintEvent(QPaintEvent *)
     p.drawRect(filled);
   }
 
+  // Histogram — drawn after the track so the track does not cover it. Bins go
+  // through value_to_canvas() like the handles, so the bin under a handle
+  // corresponds to that handle's value.
+  const float ymax = hist_y_.empty() ? 0.f
+                                     : *std::max_element(hist_y_.begin(),
+                                                         hist_y_.end());
+  if (ymax > 0.f)
+  {
+    p.setRenderHint(QPainter::Antialiasing, false);
+    p.setPen(Qt::NoPen);
+
+    const int  n = static_cast<int>(hist_y_.size());
+    const bool use_x = static_cast<int>(hist_x_.size()) == n;
+
+    // Bin center in value space; uniform spacing over the domain when no
+    // matching hist_x_ is available.
+    auto center = [&](int i)
+    {
+      return use_x ? hist_x_[static_cast<size_t>(i)]
+                   : domain_min_ + (float(i) + 0.5f) / float(n) *
+                                       (domain_max_ - domain_min_);
+    };
+
+    QColor c_out = palette().color(QPalette::Text);
+    c_out.setAlpha(110);
+    QColor c_in = palette().color(QPalette::Highlight);
+    c_in.setAlpha(180);
+
+    for (int i = 0; i < n; ++i)
+    {
+      // Bin edges sit halfway to the neighbouring centers.
+      const float cm = center(i);
+      float       e0, e1;
+      if (n == 1)
+      {
+        e0 = domain_min_;
+        e1 = domain_max_;
+      }
+      else if (i == 0)
+      {
+        e1 = 0.5f * (cm + center(1));
+        e0 = cm - (e1 - cm);
+      }
+      else if (i == n - 1)
+      {
+        e0 = 0.5f * (center(i - 1) + cm);
+        e1 = cm + (cm - e0);
+      }
+      else
+      {
+        e0 = 0.5f * (center(i - 1) + cm);
+        e1 = 0.5f * (cm + center(i + 1));
+      }
+
+      const int x0 = value_to_canvas(e0);
+      const int x1 = std::max(value_to_canvas(e1), x0 + 1);
+
+      const float h = (hist_y_[static_cast<size_t>(i)] / ymax) *
+                      float(rect().height());
+      const bool in_sel = cm >= value_.x && cm <= value_.y;
+      p.setBrush(in_sel ? c_in : c_out);
+      p.drawRect(QRectF(x0, rect().bottom() - h, x1 - x0, h));
+    }
+
+    p.setRenderHint(QPainter::Antialiasing, true);
+  }
+  else if (hist_provided_)
+  {
+    // A provider ran but produced nothing (empty or flat input) — say so
+    // instead of being indistinguishable from a broken widget.
+    QColor c = palette().color(QPalette::Text);
+    c.setAlpha(120);
+    QFont f = p.font();
+    f.setItalic(true);
+    p.setFont(f);
+    p.setPen(c);
+    p.drawText(QRect(tr.left(), 0, tr.width(), tr.top() - 2),
+               Qt::AlignHCenter | Qt::AlignBottom,
+               QObject::tr("no histogram data"));
+  }
+
   // Track border
   p.setPen(QPen(palette().color(QPalette::Dark), 1));
   p.setBrush(Qt::NoBrush);
   p.drawRoundedRect(tr, 3, 3);
 
-  // Draw a handle: a rounded rectangle straddling the track vertically
+  // Draw a handle: a rounded rectangle straddling the track vertically,
+  // outlined with the text color so it stays visible on the track.
   auto draw_handle = [&](int x, bool hovered, bool dragged)
   {
     const QRect hr(x - handle_w_, tr.top() - 3, handle_w_ * 2, tr.height() + 6);
-    p.setPen(QPen(palette().color(QPalette::Dark), 1));
+    p.setPen(QPen(palette().color(QPalette::Text), 1));
     p.setBrush(dragged   ? palette().color(QPalette::Highlight)
                : hovered ? palette().color(QPalette::Light)
                          : palette().color(QPalette::Button));
@@ -257,6 +315,7 @@ void RangeBar::set_histogram(const std::vector<float> &x,
 {
   this->hist_x_ = x;
   this->hist_y_ = y;
+  this->hist_provided_ = true;
   this->update();
 }
 

--- a/tests/test_qt/rangebar_snap/CMakeLists.txt
+++ b/tests/test_qt/rangebar_snap/CMakeLists.txt
@@ -1,0 +1,2 @@
+add_executable(rangebar_snap main.cpp)
+target_link_libraries(rangebar_snap meta meta_qt)

--- a/tests/test_qt/rangebar_snap/main.cpp
+++ b/tests/test_qt/rangebar_snap/main.cpp
@@ -1,0 +1,68 @@
+// Offscreen snapshot harness for RangeBar (issues #23 / #20). Renders the
+// widget in several histogram configurations to PNG files for visual review.
+// Not part of the test suite; run with QT_QPA_PLATFORM=offscreen.
+#include <cmath>
+#include <vector>
+
+#include <QApplication>
+#include <QDir>
+
+#include "meta_qt/widgets/range_bar.hpp"
+
+using meta::qt::RangeBar;
+
+static void snap(QWidget &w, const QString &path)
+{
+  w.resize(420, 44);
+  w.grab().save(path);
+}
+
+int main(int argc, char **argv)
+{
+  QApplication app(argc, argv);
+  const QString dir = argc > 1 ? argv[1] : ".";
+  QDir().mkpath(dir);
+
+  // Bell-ish histogram over the full domain [0, 1]
+  std::vector<float> x, y;
+  const int          n = 60;
+  for (int i = 0; i < n; ++i)
+  {
+    const float cx = (float(i) + 0.5f) / float(n);
+    x.push_back(cx);
+    y.push_back(std::exp(-40.f * (cx - 0.55f) * (cx - 0.55f)) +
+                0.3f * std::exp(-200.f * (cx - 0.15f) * (cx - 0.15f)));
+  }
+
+  glm::vec2 v1{0.3f, 0.8f};
+  RangeBar  full(v1, 0.f, 1.f, 2);
+  full.set_histogram(x, y);
+  snap(full, dir + "/full_domain.png");
+
+  // Partial-domain histogram: data only covers [0.5, 1.0] of a [0, 1] domain.
+  // Pre-fix this was stretched over the whole widget.
+  std::vector<float> xp, yp;
+  for (int i = 0; i < n; ++i)
+  {
+    const float cx = 0.5f + 0.5f * (float(i) + 0.5f) / float(n);
+    xp.push_back(cx);
+    yp.push_back(1.f + std::sin(12.f * cx));
+  }
+  glm::vec2 v2{0.4f, 0.7f};
+  RangeBar  partial(v2, 0.f, 1.f, 2);
+  partial.set_histogram(xp, yp);
+  snap(partial, dir + "/partial_domain.png");
+
+  // Provider ran but returned nothing → "no histogram data" hint
+  glm::vec2 v3{0.2f, 0.9f};
+  RangeBar  empty(v3, 0.f, 1.f, 2);
+  empty.set_histogram({}, {});
+  snap(empty, dir + "/empty_provider.png");
+
+  // No histogram at all → plain bar, no hint
+  glm::vec2 v4{0.2f, 0.9f};
+  RangeBar  plain(v4, 0.f, 1.f, 2);
+  snap(plain, dir + "/no_histogram.png");
+
+  return 0;
+}


### PR DESCRIPTION
Fixes #23, and implements the #20 checklist in the same pass since it is the same paint code.

**#23 — two `paintEvent` bugs:**

- Bins were laid out at a uniform pitch across the full widget width, ignoring `hist_x_`, while the handles map through `value_to_canvas()` (which spans `[min, max]` with the track inset). A bin under a handle did not correspond to that handle's value; partial- or non-uniform-domain histograms were simply wrong. Bin centers now go through `value_to_canvas()`, with bin edges halfway to the neighbouring centers, and a fallback to uniform spacing over the domain when `hist_x_` doesn't match `hist_y_` in size (callers don't guarantee it).
- The histogram was `QPalette::Mid` at alpha 90, painted *before* the track drawn in the same role at full alpha — same-hue-on-same-hue and partially covered. It is now drawn after the track fill with its own roles.

**#20 checklist:**

- [x] handle borders use the widget's text color (was `Dark`), visible on the track;
- [x] bins whose center falls inside the current selection use the accent (`Highlight`) color;
- [x] bins outside the selection are unchanged — neutral `Text` at reduced alpha.

**Also from #23 ("related")**: a provider that runs but produces no histogram (empty/flat input — e.g. Hesiod's `Saturate`) now yields a faint italic *no histogram data* hint instead of drawing nothing, which was indistinguishable from a broken widget. `glm_vec2.inl` forwards the empty result instead of dropping it; a bar with no provider at all still draws nothing extra.

**Review aid**: `tests/test_qt/rangebar_snap` (built with the Qt tests) renders the four states — full-domain, partial-domain, empty-provider, no-histogram — to PNGs offscreen:

```
QT_QPA_PLATFORM=offscreen ./build/bin/rangebar_snap /tmp/rangebar
```

Verified here on Debug builds before/after: pre-fix, a histogram covering `[0.5, 1.0]` of a `[0, 1]` domain stretched across the whole widget as a faint wash behind the track; post-fix it occupies exactly the right half, aligned with the handles, accent-colored inside the selection.
