### PR TITLE
fix(qt): int Input rounds instead of truncating and clamps into the model

### DIFF
--- a/MetaUI/qt/include/meta_qt/widget_renderer_inl/int.inl
+++ b/MetaUI/qt/include/meta_qt/widget_renderer_inl/int.inl
@@ -2,6 +2,7 @@
    Public License. The full license is in the file LICENSE, distributed with
    this software. */
 #pragma once
+#include <cmath>
 #include <format>
 
 #include <QComboBox>
@@ -58,8 +59,14 @@ template <> struct WidgetRenderer<int>
       spinbox->setMinimum(min);
       spinbox->setMaximum(max);
       spinbox->setSingleStep(step);
-      spinbox->setValue(std::clamp(value, min, max));
       spinbox->setDecimals(0);
+
+      // A deserialized value can sit outside the current constraints (e.g.
+      // constraints tightened in a later version); make the model agree with
+      // the clamped value that is displayed instead of keeping the stale one.
+      const int clamped = std::clamp(value, min, max);
+      spinbox->setValue(clamped);
+      if (clamped != value) attr.set_from_any(clamped);
 
       layout->addWidget(spinbox);
 
@@ -70,16 +77,20 @@ template <> struct WidgetRenderer<int>
             spinbox->setValue(value);
           });
 
-      QObject::connect(spinbox,
-                       &QDoubleSpinBox::valueChanged,
-                       spinbox,
-                       [&attr, widget, min, max](int v)
-                       {
-                         attr.set_from_any(std::clamp(v, min, max));
-                         Q_EMIT widget->edit_started();
-                         Q_EMIT widget->value_changed();
-                         Q_EMIT widget->edit_ended();
-                       });
+      QObject::connect(
+          spinbox,
+          &QDoubleSpinBox::valueChanged,
+          spinbox,
+          [&attr, widget, min, max](double v)
+          {
+            // Round explicitly: an implicit double -> int conversion
+            // truncates toward zero.
+            const int iv = static_cast<int>(std::lround(v));
+            attr.set_from_any(std::clamp(iv, min, max));
+            Q_EMIT widget->edit_started();
+            Q_EMIT widget->value_changed();
+            Q_EMIT widget->edit_ended();
+          });
     }
     else if (widget_type == "EnumComboBox")
     {

--- a/tests/test_qt/test_int_input/CMakeLists.txt
+++ b/tests/test_qt/test_int_input/CMakeLists.txt
@@ -1,0 +1,2 @@
+add_executable(test_int_input main.cpp)
+target_link_libraries(test_int_input meta meta_qt)

--- a/tests/test_qt/test_int_input/main.cpp
+++ b/tests/test_qt/test_int_input/main.cpp
@@ -1,0 +1,38 @@
+// Regression test for the int "Input" widget (issue #24): a model value
+// outside the current constraints must be clamped back into the model at
+// construction, not only in the display. Run with QT_QPA_PLATFORM=offscreen.
+#include <cassert>
+
+#include <QApplication>
+
+#include "meta.hpp"
+#include "meta_qt/meta_widget.hpp"
+#include "meta_qt/widget_renderer.hpp"
+
+int main(int argc, char **argv)
+{
+  QApplication app(argc, argv);
+
+  // Value above the constraint range, as left behind by a file saved before
+  // the constraints were tightened.
+  meta::Attribute<int> attr("i", 25);
+  attr.metadata().add(meta::keys::constraints::min, 0);
+  attr.metadata().add(meta::keys::constraints::max, 10);
+
+  auto *w = meta::qt::WidgetRenderer<int>::render(attr, nullptr);
+  assert(w);
+  assert(attr.value() == 10); // model agrees with the clamped display
+
+  // An in-range value must pass through untouched.
+  meta::Attribute<int> attr2("i", 5);
+  attr2.metadata().add(meta::keys::constraints::min, 0);
+  attr2.metadata().add(meta::keys::constraints::max, 10);
+
+  auto *w2 = meta::qt::WidgetRenderer<int>::render(attr2, nullptr);
+  assert(w2);
+  assert(attr2.value() == 5);
+
+  delete w;
+  delete w2;
+  return 0;
+}


### PR DESCRIPTION
Fixes #24 — both findings.

**Truncation**: the `QDoubleSpinBox::valueChanged(double)` signal was connected to a lambda taking `int`, so the conversion was implicit and truncated toward zero (and the wrong way for negatives, relative to what's displayed). The slot now takes `double` and rounds explicitly with `std::lround`.

**Display-only clamp**: `spinbox->setValue(std::clamp(value, min, max))` clamped the display while the attribute kept its out-of-range value — widget and model disagreed from the first frame, and the stale value stayed live unless the user happened to touch the control. This is exactly the situation when a file saved under looser constraints is loaded after they were tightened. The clamped value is now written back to the attribute at construction (silently — no `value_changed` emission during setup).

**Test**: `tests/test_qt/test_int_input` renders the widget offscreen (`QT_QPA_PLATFORM=offscreen`) for an attribute holding 25 under `constraints.max = 10` and asserts the model comes out clamped, plus an in-range pass-through case. Verified both ways on a Debug build: aborts on the assert without the fix, exits 0 with it.
