### PR TITLE
fix(qt): vec2 range Center uses the domain midpoint; no-op buttons disabled

### DIFF
--- a/MetaUI/qt/include/meta_qt/widget_renderer_inl/glm_vec2.inl
+++ b/MetaUI/qt/include/meta_qt/widget_renderer_inl/glm_vec2.inl
@@ -302,11 +302,16 @@ template <> struct WidgetRenderer<glm::vec2>
       layout->addLayout(btn_row);
 
       // Enable or disable all range controls according to the sentinel state.
-      auto set_active = [bar, reset_btn, center_btn, unit_btn](bool active)
+      // Buttons that cannot change the current value stay disabled: "Full"
+      // when the range already spans the whole domain, "Center" when the
+      // span covers the domain and cannot be shifted.
+      auto set_active =
+          [&value, bar, reset_btn, center_btn, unit_btn, min, max](bool active)
       {
+        const bool full_domain = value.x <= min && value.y >= max;
         bar->setEnabled(active);
-        reset_btn->setEnabled(active);
-        center_btn->setEnabled(active);
+        reset_btn->setEnabled(active && !full_domain);
+        center_btn->setEnabled(active && value.y - value.x < max - min);
         unit_btn->setEnabled(active);
       };
 
@@ -362,7 +367,6 @@ template <> struct WidgetRenderer<glm::vec2>
                        {
                          toggle_btn->setText(active ? QObject::tr("On")
                                                     : QObject::tr("Off"));
-                         set_active(active);
 
                          if (active)
                          {
@@ -378,6 +382,9 @@ template <> struct WidgetRenderer<glm::vec2>
                            bar->set_value({-1.f, 0.f});
                          }
 
+                         // After the value update so button states reflect it.
+                         set_active(active);
+
                          Q_EMIT widget->edit_started();
                          Q_EMIT widget->value_changed();
                          Q_EMIT widget->edit_ended();
@@ -387,8 +394,9 @@ template <> struct WidgetRenderer<glm::vec2>
       QObject::connect(bar,
                        &RangeBar::value_changed,
                        widget,
-                       [widget](glm::vec2)
+                       [widget, set_active](glm::vec2)
                        {
+                         set_active(true); // refresh button states
                          Q_EMIT widget->edit_started();
                          Q_EMIT widget->value_changed();
                        });
@@ -403,10 +411,11 @@ template <> struct WidgetRenderer<glm::vec2>
       QObject::connect(reset_btn,
                        &QPushButton::clicked,
                        widget,
-                       [&attr, min, max, bar, widget]()
+                       [&attr, min, max, bar, widget, set_active]()
                        {
                          bar->set_value({min, max});
                          attr.set_from_any(glm::vec2{min, max});
+                         set_active(true);
                          Q_EMIT widget->edit_started();
                          Q_EMIT widget->value_changed();
                          Q_EMIT widget->edit_ended();
@@ -417,13 +426,14 @@ template <> struct WidgetRenderer<glm::vec2>
           center_btn,
           &QPushButton::clicked,
           widget,
-          [&value, &attr, min, max, bar, widget]()
+          [&value, &attr, min, max, bar, widget, set_active]()
           {
             const float span = value.y - value.x;
-            const float mid = 0.f; // (min + max) * 0.5f;
+            const float mid = (min + max) * 0.5f;
             const float lo = std::clamp(mid - span * 0.5f, min, max - span);
             bar->set_value({lo, lo + span});
             attr.set_from_any(glm::vec2{lo, lo + span});
+            set_active(true);
             Q_EMIT widget->edit_started();
             Q_EMIT widget->value_changed();
             Q_EMIT widget->edit_ended();
@@ -433,12 +443,13 @@ template <> struct WidgetRenderer<glm::vec2>
       QObject::connect(unit_btn,
                        &QPushButton::clicked,
                        widget,
-                       [&attr, min, max, bar, widget]()
+                       [&attr, min, max, bar, widget, set_active]()
                        {
                          const float lo = std::clamp(0.f, min, max);
                          const float hi = std::clamp(1.f, min, max);
                          bar->set_value({lo, hi});
                          attr.set_from_any(glm::vec2{lo, hi});
+                         set_active(true);
                          Q_EMIT widget->edit_started();
                          Q_EMIT widget->value_changed();
                          Q_EMIT widget->edit_ended();

--- a/tests/test_qt/test_vec2_range/CMakeLists.txt
+++ b/tests/test_qt/test_vec2_range/CMakeLists.txt
@@ -1,0 +1,2 @@
+add_executable(test_vec2_range main.cpp)
+target_link_libraries(test_vec2_range meta meta_qt)

--- a/tests/test_qt/test_vec2_range/main.cpp
+++ b/tests/test_qt/test_vec2_range/main.cpp
@@ -1,0 +1,57 @@
+// Regression test for the glm::vec2 RangeBar widget buttons (issue #25):
+// "Center" must centre the span on the domain midpoint, and buttons that
+// cannot change the value must be disabled. Run with
+// QT_QPA_PLATFORM=offscreen.
+#include <cassert>
+#include <cmath>
+
+#include <QApplication>
+#include <QPushButton>
+
+#include "meta.hpp"
+#include "meta_qt/meta_widget.hpp"
+#include "meta_qt/widget_renderer.hpp"
+
+static QPushButton *find_button(QWidget *w, const QString &text)
+{
+  for (auto *btn : w->findChildren<QPushButton *>())
+    if (btn->text() == text) return btn;
+  return nullptr;
+}
+
+static bool near(float a, float b)
+{
+  return std::fabs(a - b) < 1e-5f;
+}
+
+int main(int argc, char **argv)
+{
+  QApplication app(argc, argv);
+
+  meta::Attribute<glm::vec2> attr("range", glm::vec2(0.2f, 0.4f));
+  attr.metadata().add(meta::keys::ui::widget_type, "RangeBar");
+  attr.metadata().add(meta::keys::constraints::min, 0.f);
+  attr.metadata().add(meta::keys::constraints::max, 1.f);
+
+  auto *w = meta::qt::WidgetRenderer<glm::vec2>::render(attr, nullptr);
+  assert(w);
+
+  auto *center_btn = find_button(w, QObject::tr("Center"));
+  auto *full_btn = find_button(w, QObject::tr("Full"));
+  assert(center_btn && full_btn);
+
+  // Span 0.2 centred on the domain midpoint 0.5 -> [0.4, 0.6].
+  // (Pre-fix this centred on 0 and slammed the range to [0.0, 0.2].)
+  center_btn->click();
+  assert(near(attr.value().x, 0.4f) && near(attr.value().y, 0.6f));
+
+  // A full-domain range: "Full" is a no-op and "Center" cannot shift the
+  // span — both must be disabled.
+  full_btn->click();
+  assert(near(attr.value().x, 0.f) && near(attr.value().y, 1.f));
+  assert(!full_btn->isEnabled());
+  assert(!center_btn->isEnabled());
+
+  delete w;
+  return 0;
+}


### PR DESCRIPTION
Fixes #25 — both findings.

**Center on the midpoint**: `mid` was hardcoded to `0.f` with the correct expression commented out beside it. For any domain not centred on zero — `[0, 1]` being the common case — "Center" slammed the range to the bottom of the domain. It now uses `(min + max) * 0.5f`, matching the `XYCanvas` branch's Center button in the same file.

**No-op buttons disabled**: at full span, "Center" cannot shift anything, and once the range is the full domain, "Full" cannot change it — both were silent no-ops. `set_active` now derives their enabled state from the current value, and the state refreshes wherever the value changes: bar drags, the three buttons, the on/off toggle (whose `set_active` call moved to after the value update so it sees the restored range), and `sync_from_model` (which already called `set_active` with the model value current).

**Test**: `tests/test_qt/test_vec2_range` renders the widget offscreen, clicks "Center" on a `[0.2, 0.4]` range over a `[0, 1]` domain and asserts `[0.4, 0.6]` (pre-fix: `[0.0, 0.2]`), then clicks "Full" and asserts both buttons come back disabled. Verified both ways on a Debug build: aborts on the assert without the fix, exits 0 with it.

Note: touches the same file as #29 but disjoint hunks; whichever merges second should rebase cleanly.
