### PR TITLE
feat: add option to synchronize shared attributes across containers i…

### DIFF
--- a/Meta/include/meta/core/abstract_attribute.hpp
+++ b/Meta/include/meta/core/abstract_attribute.hpp
@@ -14,6 +14,7 @@
 
 #include <nlohmann/json.hpp>
 
+#include "meta/core/event.hpp"
 #include "meta/core/meta_object.hpp"
 #include "meta/serialization/serialization_mode.hpp"
 
@@ -35,6 +36,9 @@ class AbstractAttribute : public MetaObject
 {
 public:
   virtual ~AbstractAttribute() = default;
+
+  /// Untyped event fired whenever the attribute value changes.
+  Event<AbstractAttribute &> value_changed_event;
 
   /// Returns the attribute name.
   virtual const std::string &name() const = 0;

--- a/Meta/include/meta/core/attribute.hpp
+++ b/Meta/include/meta/core/attribute.hpp
@@ -66,6 +66,22 @@ public:
   Attribute(std::string name, T value)
       : name_(std::move(name)), value_(std::move(value))
   {
+    value_changed_conn_ = value_changed.subscribe(
+        [this](const T &) { value_changed_event.notify(*this); });
+  }
+
+  /// Sets value and notifies subscribers.
+  void set_value(const T &new_value)
+  {
+    value_ = new_value;
+    value_changed.notify(value_);
+  }
+
+  /// Sets value (by move) and notifies subscribers.
+  void set_value(T &&new_value)
+  {
+    value_ = std::move(new_value);
+    value_changed.notify(value_);
   }
 
   /// Get attribute name.
@@ -179,8 +195,9 @@ public:
   }
 
 private:
-  std::string name_;
-  T           value_;
+  std::string     name_;
+  T               value_;
+  EventConnection value_changed_conn_;
 };
 
 } // namespace meta

--- a/Meta/include/meta/core/attribute_container.hpp
+++ b/Meta/include/meta/core/attribute_container.hpp
@@ -59,6 +59,9 @@ concept StringLike = std::is_same_v<std::decay_t<T>, std::string> ||
 class AttributeContainer : public MetaObject
 {
 public:
+  Event<AbstractAttribute &> attribute_added;
+  Event<const std::string &> attribute_removed;
+
   // -------------------------------------------------------------------------
   // Capacity
   // -------------------------------------------------------------------------
@@ -140,6 +143,8 @@ public:
     // keep track of insertion order
     insertion_order_.push_back(name);
 
+    attribute_added.notify(*ptr);
+
     return ptr;
   }
 
@@ -174,6 +179,8 @@ public:
     // keep track of insertion order
     insertion_order_.push_back(name);
 
+    attribute_added.notify(*ptr);
+
     return ptr;
   }
 
@@ -196,6 +203,8 @@ public:
 
     // keep track of insertion order
     insertion_order_.push_back(name);
+
+    attribute_added.notify(*ptr);
 
     return ptr;
   }
@@ -225,6 +234,8 @@ public:
 
     // keep track of insertion order
     insertion_order_.push_back(name);
+
+    attribute_added.notify(*ptr);
 
     return ptr;
   }

--- a/Meta/include/meta/core/container_group.hpp
+++ b/Meta/include/meta/core/container_group.hpp
@@ -12,6 +12,8 @@
 #include <memory>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
+#include <vector>
 
 #include "meta/core/attribute_container.hpp"
 #include "meta/core/meta_object.hpp"
@@ -81,7 +83,7 @@ public:
    */
   const AttributeContainer *find(const std::string &key) const;
 
-  /// Returns the attribute names in insertion order.
+  /// Returns the container names in insertion order.
   const std::vector<std::string> &insertion_order() const;
 
   /**
@@ -92,6 +94,68 @@ public:
 
   /// Clear all containers.
   void clear();
+
+  // -------------------------------------------------------------------------
+  // Attribute Synchronization
+  // -------------------------------------------------------------------------
+
+  /**
+   * @brief Detects attribute keys shared across at least two containers with
+   *        matching types.
+   * @return Vector of shared attribute keys in insertion order.
+   */
+  std::vector<std::string> shared_attributes() const;
+
+  /**
+   * @brief Checks whether an attribute key is shared across at least two
+   *        containers with matching types.
+   * @param key Attribute identifier.
+   * @return true if shared, false otherwise.
+   */
+  bool is_shared(const std::string &key) const;
+
+  /**
+   * @brief Enable or disable synchronization for an attribute key across
+   *        containers in this group.
+   *
+   * When enabled, the attribute's current value (from the active container, or
+   * the first container containing it) is propagated to all matching
+   * containers, and subsequent updates in any container are kept in sync.
+   *
+   * @param key Attribute identifier.
+   * @param synchronize Whether to synchronize.
+   */
+  void set_synchronized(const std::string &key, bool synchronize = true);
+
+  /**
+   * @brief Check whether an attribute is marked for synchronization.
+   * @param key Attribute identifier.
+   * @return true if synchronized.
+   */
+  bool is_synchronized(const std::string &key) const;
+
+  /**
+   * @brief Get the set of currently synchronized attribute keys.
+   * @return Constant reference to the set of synchronized attribute names.
+   */
+  const std::unordered_set<std::string> &synchronized_attributes() const;
+
+  /**
+   * @brief Synchronizes all detected shared attributes across containers.
+   * @param synchronize Whether to enable or disable synchronization for all.
+   */
+  void synchronize_all(bool synchronize = true);
+
+  /// Disables synchronization for all attributes.
+  void clear_synchronizations();
+
+  /**
+   * @brief Manually propagate the value of an attribute from the active
+   *        container (or first containing container) to all other matching
+   *        containers in the group.
+   * @param key Attribute identifier.
+   */
+  void sync_attribute(const std::string &key);
 
   // -------------------------------------------------------------------------
   // Serialization
@@ -134,6 +198,19 @@ private:
   ContainerMap             containers_;
   std::vector<std::string> insertion_order_;
   AttributeContainer      *current_ = nullptr;
+
+  std::unordered_set<std::string> synchronized_attributes_;
+  bool                            is_synchronizing_ = false;
+
+  // Track event connections per container
+  std::unordered_map<std::string, std::vector<EventConnection>>
+      container_connections_;
+
+  void bind_container(const std::string &key, AttributeContainer &container);
+  void bind_attribute(const std::string &container_key,
+                      AbstractAttribute &attr);
+  void sync_attribute_across_containers(const std::string &key,
+                                        AbstractAttribute &source);
 
   /**
    * @brief Removes stale entries from insertion_order_ that no longer exist

--- a/Meta/src/attribute_container.cpp
+++ b/Meta/src/attribute_container.cpp
@@ -38,6 +38,10 @@ ConstAttrIterator AttributeContainer::cend() const
 void AttributeContainer::clear()
 {
   Logger::log()->trace("AttributeContainer::clear");
+
+  for (const auto &name : insertion_order_)
+    attribute_removed.notify(name);
+
   attributes_.clear();
   compact_insertion_order();
 }
@@ -179,6 +183,7 @@ void AttributeContainer::json_from(const nlohmann::json &j,
                                                        std::move(new_attr));
 
       it = insert_it;
+      attribute_added.notify(*it->second);
     }
     else
     {

--- a/Meta/src/container_group.cpp
+++ b/Meta/src/container_group.cpp
@@ -29,7 +29,99 @@ AttributeContainer &ContainerGroup::add(const std::string &key)
 
   insertion_order_.push_back(key);
 
+  bind_container(key, *it->second);
+
   return *it->second;
+}
+
+void ContainerGroup::bind_container(const std::string  &key,
+                                    AttributeContainer &container)
+{
+  Logger::log()->trace("ContainerGroup::bind_container: key = {}", key);
+
+  auto &conns = container_connections_[key];
+
+  // Subscribe to attribute_added
+  conns.push_back(container.attribute_added.subscribe(
+      [this, key](AbstractAttribute &attr)
+      {
+        bind_attribute(key, attr);
+        if (is_synchronized(attr.name()))
+        {
+          if (!is_synchronizing_)
+          {
+            // Find a source container that has this attribute
+            AbstractAttribute *source = nullptr;
+            if (current_ && current_ != find(key))
+            {
+              source = current_->find(attr.name());
+            }
+            if (!source)
+            {
+              for (const auto &cname : insertion_order_)
+              {
+                if (cname == key) continue;
+                auto *c = find(cname);
+                if (c && (source = c->find(attr.name()))) break;
+              }
+            }
+            if (source && source->type() == attr.type())
+            {
+              is_synchronizing_ = true;
+              attr.set_from_any(source->to_any());
+              is_synchronizing_ = false;
+            }
+          }
+        }
+      }));
+
+  // Bind any attributes already in the container
+  for (auto &attr : container)
+  {
+    bind_attribute(key, *attr.second);
+  }
+}
+
+void ContainerGroup::bind_attribute(const std::string &container_key,
+                                    AbstractAttribute &attr)
+{
+  auto &conns = container_connections_[container_key];
+  conns.push_back(attr.value_changed_event.subscribe(
+      [this, attr_name = attr.name()](AbstractAttribute &source)
+      {
+        if (is_synchronizing_) return;
+        if (!is_synchronized(attr_name)) return;
+
+        is_synchronizing_ = true;
+        sync_attribute_across_containers(attr_name, source);
+        is_synchronizing_ = false;
+      }));
+}
+
+void ContainerGroup::sync_attribute_across_containers(const std::string &key,
+                                                      AbstractAttribute &source)
+{
+  std::any        val = source.to_any();
+  std::type_index src_type = source.type();
+
+  for (auto &[cname, container] : containers_)
+  {
+    if (!container) continue;
+    auto *target_attr = container->find(key);
+    if (!target_attr || target_attr == &source) continue;
+
+    if (target_attr->type() == src_type)
+    {
+      target_attr->set_from_any(val);
+    }
+    else
+    {
+      Logger::log()->warn("ContainerGroup::sync_attribute: type mismatch for "
+                          "attribute '{}' in container '{}'",
+                          key,
+                          cname);
+    }
+  }
 }
 
 void ContainerGroup::compact_insertion_order()
@@ -101,6 +193,7 @@ bool ContainerGroup::erase(const std::string &key)
 
   const bool was_current = (current_ == it->second.get());
 
+  container_connections_.erase(key);
   containers_.erase(it);
 
   if (was_current)
@@ -156,9 +249,152 @@ void ContainerGroup::set_current(const std::string &key)
 void ContainerGroup::clear()
 {
   Logger::log()->trace("ContainerGroup::clear");
+  container_connections_.clear();
   containers_.clear();
   insertion_order_.clear();
+  synchronized_attributes_.clear();
   current_ = nullptr;
+}
+
+std::vector<std::string> ContainerGroup::shared_attributes() const
+{
+  std::unordered_map<std::string, std::unordered_map<std::type_index, size_t>>
+                           counts;
+  std::vector<std::string> order;
+
+  for (const auto &cname : insertion_order_)
+  {
+    auto it = containers_.find(cname);
+    if (it == containers_.end() || !it->second) continue;
+
+    for (const auto &attr_name : it->second->insertion_order())
+    {
+      const auto *attr = it->second->find(attr_name);
+      if (!attr) continue;
+
+      if (!counts.contains(attr_name))
+      {
+        order.push_back(attr_name);
+      }
+      counts[attr_name][attr->type()]++;
+    }
+  }
+
+  std::vector<std::string> result;
+  for (const auto &attr_name : order)
+  {
+    for (const auto &[type, count] : counts[attr_name])
+    {
+      if (count >= 2)
+      {
+        result.push_back(attr_name);
+        break;
+      }
+    }
+  }
+  return result;
+}
+
+bool ContainerGroup::is_shared(const std::string &key) const
+{
+  std::unordered_map<std::type_index, size_t> type_counts;
+  for (const auto &[_, container] : containers_)
+  {
+    if (!container) continue;
+    if (const auto *attr = container->find(key))
+    {
+      type_counts[attr->type()]++;
+      if (type_counts[attr->type()] >= 2)
+      {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+void ContainerGroup::set_synchronized(const std::string &key, bool synchronize)
+{
+  Logger::log()->trace("ContainerGroup::set_synchronized: key='{}', sync={}",
+                       key,
+                       synchronize);
+
+  if (synchronize)
+  {
+    synchronized_attributes_.insert(key);
+    sync_attribute(key);
+  }
+  else
+  {
+    synchronized_attributes_.erase(key);
+  }
+}
+
+bool ContainerGroup::is_synchronized(const std::string &key) const
+{
+  return synchronized_attributes_.contains(key);
+}
+
+const std::unordered_set<std::string> &ContainerGroup::synchronized_attributes()
+    const
+{
+  return synchronized_attributes_;
+}
+
+void ContainerGroup::synchronize_all(bool synchronize)
+{
+  Logger::log()->trace("ContainerGroup::synchronize_all: sync={}", synchronize);
+
+  if (synchronize)
+  {
+    for (const auto &attr_name : shared_attributes())
+    {
+      set_synchronized(attr_name, true);
+    }
+  }
+  else
+  {
+    clear_synchronizations();
+  }
+}
+
+void ContainerGroup::clear_synchronizations()
+{
+  Logger::log()->trace("ContainerGroup::clear_synchronizations");
+  synchronized_attributes_.clear();
+}
+
+void ContainerGroup::sync_attribute(const std::string &key)
+{
+  Logger::log()->trace("ContainerGroup::sync_attribute: key='{}'", key);
+
+  AbstractAttribute *source = nullptr;
+  if (current_)
+  {
+    source = current_->find(key);
+  }
+
+  if (!source)
+  {
+    for (const auto &cname : insertion_order_)
+    {
+      auto it = containers_.find(cname);
+      if (it != containers_.end() && it->second)
+      {
+        if ((source = it->second->find(key)))
+        {
+          break;
+        }
+      }
+    }
+  }
+
+  if (source)
+  {
+    is_synchronizing_ = true;
+    sync_attribute_across_containers(key, *source);
+    is_synchronizing_ = false;
+  }
 }
 
 nlohmann::json ContainerGroup::json_to(SerializationMode mode) const
@@ -170,6 +406,11 @@ nlohmann::json ContainerGroup::json_to(SerializationMode mode) const
   if (auto current_name = current_container_name())
   {
     j["current"] = *current_name;
+  }
+
+  if (!synchronized_attributes_.empty())
+  {
+    j["synchronized_attributes"] = synchronized_attributes_;
   }
 
   nlohmann::json containers_json = nlohmann::json::object();
@@ -220,7 +461,7 @@ void ContainerGroup::json_from(const nlohmann::json &j,
 
   for (const auto &[name, container_val] : containers_json->items())
   {
-    if (name == "current")
+    if (name == "current" || name == "synchronized_attributes")
     {
       continue;
     }
@@ -270,6 +511,18 @@ void ContainerGroup::json_from(const nlohmann::json &j,
       Logger::log()->warn(
           "ContainerGroup::json_from: current container '{}' not found",
           current_name);
+    }
+  }
+
+  if (j.contains("synchronized_attributes") &&
+      j["synchronized_attributes"].is_array())
+  {
+    for (const auto &attr_val : j["synchronized_attributes"])
+    {
+      if (attr_val.is_string())
+      {
+        set_synchronized(attr_val.get<std::string>(), true);
+      }
     }
   }
 }

--- a/tests/test_qt/test_meta_qt/main.cpp
+++ b/tests/test_qt/test_meta_qt/main.cpp
@@ -776,9 +776,7 @@ void add_array_tests(meta::AttributeContainer &container)
 void add_group_tests(meta::ContainerGroup &group)
 {
   auto &node_settings = group.add("node_settings");
-
   auto &ui_settings = group.add("ui_settings");
-
   auto &debug_settings = group.add("debug_settings");
 
   group.set_current("node_settings");
@@ -791,11 +789,8 @@ void add_group_tests(meta::ContainerGroup &group)
     auto *a = node_settings.add("threshold", 0.5f);
 
     a->metadata().add(meta::keys::constraints::min, 0.f);
-
     a->metadata().add(meta::keys::constraints::max, 5.f);
-
     a->metadata().add(meta::keys::ui::widget_type, "Slider");
-
     a->metadata().add(meta::keys::ui::category, "Base/Something/Category 2");
   }
 
@@ -812,9 +807,7 @@ void add_group_tests(meta::ContainerGroup &group)
   // ---------------------------------------------------------------------------
 
   ui_settings.add("theme", std::string("dark"));
-
   ui_settings.add("font_size", 14.f);
-
   ui_settings.add("show_grid", true);
 
   // ---------------------------------------------------------------------------
@@ -822,18 +815,18 @@ void add_group_tests(meta::ContainerGroup &group)
   // ---------------------------------------------------------------------------
 
   debug_settings.add("log_level", 2);
-
   debug_settings.add("wireframe", false);
-
   debug_settings.add("draw_bounds", true);
+  debug_settings.add("show_grid", true);
 
   // ---------------------------------------------------------------------------
   // Presets
   // ---------------------------------------------------------------------------
 
   meta::presets::seed(node_settings, "seed", "Random Seed");
-
   meta::presets::angle(node_settings, "angle", "Angle");
+
+  group.synchronize_all();
 }
 
 // -----------------------------------------------------------------------------

--- a/tests/unittests/CMakeLists.txt
+++ b/tests/unittests/CMakeLists.txt
@@ -23,6 +23,7 @@ add_executable(meta_unittests
   test_serialization.cpp
   test_attribute_factory.cpp
   test_event.cpp
+  test_container_group_sync.cpp
 )
 
 target_link_libraries(meta_unittests

--- a/tests/unittests/test_container_group_sync.cpp
+++ b/tests/unittests/test_container_group_sync.cpp
@@ -1,0 +1,276 @@
+/* Copyright (c) 2026 Otto Link. Distributed under the terms of the GNU General
+   Public License. The full license is in the file LICENSE, distributed with
+   this software. */
+#include <gtest/gtest.h>
+
+#include "meta/core/container_group.hpp"
+
+TEST(ContainerGroupSyncTest, DetectSharedAttributes)
+{
+  meta::ContainerGroup group;
+
+  auto &c1 = group.add("Feature1");
+  c1.add("scale", 1.0f);
+  c1.add("intensity", 0.5f);
+  c1.add("specific1", 10);
+  c1.add("tag", std::string("alpha"));
+
+  auto &c2 = group.add("Feature2");
+  c2.add("scale", 2.0f);
+  c2.add("intensity", 0.8f);
+  c2.add("specific2", 20);
+  c2.add("tag", std::string("beta"));
+
+  auto &c3 = group.add("Feature3");
+  c3.add("scale", 3.0f);
+  c3.add("specific3", 30);
+  c3.add("tag", 123); // different type (int vs string)
+
+  // scale is in c1, c2, c3 (float) -> shared
+  // intensity is in c1, c2 (float) -> shared
+  // tag is in c1, c2 (string) -> shared (between c1 and c2)
+  // specific1, specific2, specific3 -> not shared
+
+  EXPECT_TRUE(group.is_shared("scale"));
+  EXPECT_TRUE(group.is_shared("intensity"));
+  EXPECT_TRUE(group.is_shared("tag"));
+  EXPECT_FALSE(group.is_shared("specific1"));
+  EXPECT_FALSE(group.is_shared("specific2"));
+  EXPECT_FALSE(group.is_shared("specific3"));
+  EXPECT_FALSE(group.is_shared("nonexistent"));
+
+  auto shared = group.shared_attributes();
+  EXPECT_EQ(shared.size(), 3u);
+  EXPECT_EQ(shared[0], "scale");
+  EXPECT_EQ(shared[1], "intensity");
+  EXPECT_EQ(shared[2], "tag");
+}
+
+TEST(ContainerGroupSyncTest, BasicSynchronizationAndIndependence)
+{
+  meta::ContainerGroup group;
+
+  auto &c1 = group.add("Feature1");
+  c1.add("scale", 1.0f);
+  c1.add("intensity", 0.5f);
+  c1.add("offset", 10);
+
+  auto &c2 = group.add("Feature2");
+  c2.add("scale", 2.0f);
+  c2.add("intensity", 0.8f);
+  c2.add("offset", 20);
+
+  // Mark only "scale" as synchronized
+  group.set_synchronized("scale", true);
+  EXPECT_TRUE(group.is_synchronized("scale"));
+  EXPECT_FALSE(group.is_synchronized("intensity"));
+  EXPECT_FALSE(group.is_synchronized("offset"));
+
+  // Initial sync should propagate current_ (Feature1) value (1.0f) to Feature2
+  EXPECT_FLOAT_EQ(c1.value<float>("scale"), 1.0f);
+  EXPECT_FLOAT_EQ(c2.value<float>("scale"), 1.0f);
+
+  // Non-synchronized attributes should remain independent
+  EXPECT_FLOAT_EQ(c1.value<float>("intensity"), 0.5f);
+  EXPECT_FLOAT_EQ(c2.value<float>("intensity"), 0.8f);
+  EXPECT_EQ(c1.value<int>("offset"), 10);
+  EXPECT_EQ(c2.value<int>("offset"), 20);
+
+  // Update scale on c1 via set_value -> c2 should update
+  c1.find("scale")->try_cast<meta::Attribute<float>>()->set_value(5.0f);
+  EXPECT_FLOAT_EQ(c1.value<float>("scale"), 5.0f);
+  EXPECT_FLOAT_EQ(c2.value<float>("scale"), 5.0f);
+
+  // Update scale on c2 via set_from_any -> c1 should update
+  c2.find("scale")->set_from_any(std::make_any<float>(7.5f));
+  EXPECT_FLOAT_EQ(c1.value<float>("scale"), 7.5f);
+  EXPECT_FLOAT_EQ(c2.value<float>("scale"), 7.5f);
+
+  // Changing non-synchronized attribute on c1 does not affect c2
+  c1.find("intensity")->try_cast<meta::Attribute<float>>()->set_value(0.1f);
+  EXPECT_FLOAT_EQ(c1.value<float>("intensity"), 0.1f);
+  EXPECT_FLOAT_EQ(c2.value<float>("intensity"), 0.8f);
+}
+
+TEST(ContainerGroupSyncTest, EventNotificationOnSync)
+{
+  meta::ContainerGroup group;
+
+  auto &c1 = group.add("Feature1");
+  c1.add("scale", 1.0f);
+
+  auto &c2 = group.add("Feature2");
+  c2.add("scale", 2.0f);
+
+  group.set_synchronized("scale", true);
+
+  float c2_notified_value = 0.0f;
+  int   c2_notification_count = 0;
+
+  auto *c2_attr = c2.find("scale")->try_cast<meta::Attribute<float>>();
+  ASSERT_NE(c2_attr, nullptr);
+
+  auto conn = c2_attr->value_changed.subscribe(
+      [&](float val)
+      {
+        c2_notified_value = val;
+        c2_notification_count++;
+      });
+
+  // Update c1
+  c1.find("scale")->try_cast<meta::Attribute<float>>()->set_value(9.0f);
+
+  EXPECT_FLOAT_EQ(c1.value<float>("scale"), 9.0f);
+  EXPECT_FLOAT_EQ(c2.value<float>("scale"), 9.0f);
+  EXPECT_EQ(c2_notification_count, 1);
+  EXPECT_FLOAT_EQ(c2_notified_value, 9.0f);
+}
+
+TEST(ContainerGroupSyncTest, EnableDisableSynchronization)
+{
+  meta::ContainerGroup group;
+
+  auto &c1 = group.add("Feature1");
+  c1.add("scale", 1.0f);
+
+  auto &c2 = group.add("Feature2");
+  c2.add("scale", 2.0f);
+
+  group.set_synchronized("scale", true);
+  EXPECT_TRUE(group.is_synchronized("scale"));
+  EXPECT_FLOAT_EQ(c2.value<float>("scale"), 1.0f);
+
+  // Disable synchronization
+  group.set_synchronized("scale", false);
+  EXPECT_FALSE(group.is_synchronized("scale"));
+
+  // Updating c1 should not affect c2 anymore
+  c1.find("scale")->try_cast<meta::Attribute<float>>()->set_value(10.0f);
+  EXPECT_FLOAT_EQ(c1.value<float>("scale"), 10.0f);
+  EXPECT_FLOAT_EQ(c2.value<float>("scale"), 1.0f);
+
+  // Updating c2 should not affect c1
+  c2.find("scale")->try_cast<meta::Attribute<float>>()->set_value(20.0f);
+  EXPECT_FLOAT_EQ(c1.value<float>("scale"), 10.0f);
+  EXPECT_FLOAT_EQ(c2.value<float>("scale"), 20.0f);
+}
+
+TEST(ContainerGroupSyncTest, SynchronizeAllAndClear)
+{
+  meta::ContainerGroup group;
+
+  auto &c1 = group.add("Feature1");
+  c1.add("a", 1.0f);
+  c1.add("b", 2.0f);
+  c1.add("c", 3);
+
+  auto &c2 = group.add("Feature2");
+  c2.add("a", 10.0f);
+  c2.add("b", 20.0f);
+  c2.add("c", 30);
+
+  group.synchronize_all(true);
+  EXPECT_TRUE(group.is_synchronized("a"));
+  EXPECT_TRUE(group.is_synchronized("b"));
+  EXPECT_TRUE(group.is_synchronized("c"));
+
+  EXPECT_FLOAT_EQ(c2.value<float>("a"), 1.0f);
+  EXPECT_FLOAT_EQ(c2.value<float>("b"), 2.0f);
+  EXPECT_EQ(c2.value<int>("c"), 3);
+
+  group.clear_synchronizations();
+  EXPECT_FALSE(group.is_synchronized("a"));
+  EXPECT_FALSE(group.is_synchronized("b"));
+  EXPECT_FALSE(group.is_synchronized("c"));
+  EXPECT_TRUE(group.synchronized_attributes().empty());
+}
+
+TEST(ContainerGroupSyncTest, DynamicAdditionOfContainersAndAttributes)
+{
+  meta::ContainerGroup group;
+
+  auto &c1 = group.add("Feature1");
+  c1.add("scale", 1.0f);
+
+  auto &c2 = group.add("Feature2");
+  c2.add("scale", 2.0f);
+
+  group.set_synchronized("scale", true);
+  EXPECT_FLOAT_EQ(c2.value<float>("scale"), 1.0f);
+
+  // Add a new container dynamically
+  auto &c3 = group.add("Feature3");
+  // Add synchronized attribute to c3
+  c3.add("scale", 99.0f);
+
+  // c3 should automatically receive the synchronized value
+  EXPECT_FLOAT_EQ(c3.value<float>("scale"), 1.0f);
+
+  // Updating c3 should update c1 and c2
+  c3.find("scale")->try_cast<meta::Attribute<float>>()->set_value(42.0f);
+  EXPECT_FLOAT_EQ(c1.value<float>("scale"), 42.0f);
+  EXPECT_FLOAT_EQ(c2.value<float>("scale"), 42.0f);
+  EXPECT_FLOAT_EQ(c3.value<float>("scale"), 42.0f);
+}
+
+TEST(ContainerGroupSyncTest, EraseContainerMaintainsSync)
+{
+  meta::ContainerGroup group;
+
+  auto &c1 = group.add("Feature1");
+  c1.add("scale", 1.0f);
+
+  auto &c2 = group.add("Feature2");
+  c2.add("scale", 2.0f);
+
+  auto &c3 = group.add("Feature3");
+  c3.add("scale", 3.0f);
+
+  group.set_synchronized("scale", true);
+
+  // Erase c2
+  EXPECT_TRUE(group.erase("Feature2"));
+  EXPECT_EQ(group.size(), 2u);
+
+  // c1 and c3 continue to sync
+  c1.find("scale")->try_cast<meta::Attribute<float>>()->set_value(15.0f);
+  EXPECT_FLOAT_EQ(c1.value<float>("scale"), 15.0f);
+  EXPECT_FLOAT_EQ(c3.value<float>("scale"), 15.0f);
+}
+
+TEST(ContainerGroupSyncTest, JsonRoundTripPreservesSync)
+{
+  meta::ContainerGroup src;
+
+  auto &c1 = src.add("Feature1");
+  c1.add("scale", 1.0f);
+  c1.add("name", std::string("Default"));
+
+  auto &c2 = src.add("Feature2");
+  c2.add("scale", 2.0f);
+  c2.add("name", std::string("Custom"));
+
+  src.set_synchronized("scale", true);
+
+  nlohmann::json j = src.json_to(meta::SerializationMode::full);
+  EXPECT_TRUE(j.contains("synchronized_attributes"));
+
+  meta::ContainerGroup dst;
+  dst.json_from(j, meta::SerializationMode::full);
+
+  EXPECT_TRUE(dst.is_synchronized("scale"));
+  EXPECT_FALSE(dst.is_synchronized("name"));
+
+  auto *dst_c1 = dst.find("Feature1");
+  auto *dst_c2 = dst.find("Feature2");
+  ASSERT_NE(dst_c1, nullptr);
+  ASSERT_NE(dst_c2, nullptr);
+
+  EXPECT_FLOAT_EQ(dst_c1->value<float>("scale"), 1.0f);
+  EXPECT_FLOAT_EQ(dst_c2->value<float>("scale"), 1.0f);
+
+  // Verify synchronization is active in deserialized group
+  dst_c1->find("scale")->try_cast<meta::Attribute<float>>()->set_value(88.0f);
+  EXPECT_FLOAT_EQ(dst_c1->value<float>("scale"), 88.0f);
+  EXPECT_FLOAT_EQ(dst_c2->value<float>("scale"), 88.0f);
+}


### PR DESCRIPTION
…n a ContainerGroup (#40)

- Add value_changed_event to AbstractAttribute for untyped notification
- Add attribute_added and attribute_removed events to AttributeContainer
- Add shared attribute detection (shared_attributes, is_shared) to ContainerGroup
- Add synchronization controls (set_synchronized, is_synchronized, synchronize_all, clear_synchronizations, sync_attribute)
- Support real-time 2-way value synchronization with recursion guard
- Support dynamic container/attribute addition and removal
- Support JSON serialization/deserialization of synchronized attributes
- Add comprehensive unit tests in test_container_group_sync.cpp