### PR TITLE
feat(qt): pluggable widget designs for attribute rows

### DIFF
--- a/MetaUI/qt/include/meta_qt/container_widget.hpp
+++ b/MetaUI/qt/include/meta_qt/container_widget.hpp
@@ -31,6 +31,14 @@ enum GroupSwitchMode
   GSM_COMBO_BOX ///< Use a combo box for switching groups
 };
 
+/** @brief Builds the widget for a single attribute.
+ *
+ * The indirection that lets a host supply an alternative widget design without
+ * the container layer knowing any design exists. Leave unset for the stock
+ * renderer; see meta_qt/ui/design_registry.hpp for the registry-backed one.
+ */
+using AttributeRowRenderer = std::function<MetaWidget *(AbstractAttribute *)>;
+
 /// Options controlling how attribute containers are rendered.
 struct ContainerRenderOptions
 {
@@ -41,6 +49,7 @@ struct ContainerRenderOptions
   std::vector<std::string> insertion_order = {};                 ///< Explicit ordering of categories
   std::optional<std::regex> collapse_regex = std::nullopt;       ///< Regex used to collapse categories
   bool snapshot_manager = false;                                 ///< Add snapshot manager widget
+  AttributeRowRenderer row_renderer = {};                        ///< Per-attribute widget builder; empty = stock
   // clang-format on
 };
 
@@ -64,9 +73,10 @@ void insert_attribute(CategoryNode            &root,
 std::string compute_flattened_path(CategoryNode *node);
 
 /// Renders a flat list of attributes into a Qt layout.
-void render_flat(CategoryNode              &node,
-                 QVBoxLayout               *layout,
-                 std::vector<MetaWidget *> &collected_widgets);
+void render_flat(CategoryNode               &node,
+                 QVBoxLayout                *layout,
+                 std::vector<MetaWidget *>  &collected_widgets,
+                 const AttributeRowRenderer &row_renderer = {});
 
 /// Renders a category tree using hierarchical grouping.
 void render_category(meta::AttributeContainer  &container,

--- a/MetaUI/qt/include/meta_qt/designs/industrial/check_row.hpp
+++ b/MetaUI/qt/include/meta_qt/designs/industrial/check_row.hpp
@@ -1,0 +1,57 @@
+/* Copyright (c) 2026 Otto Link. Distributed under the terms of the GNU General
+   Public License. The full license is in the file LICENSE, distributed with
+   this software. */
+#pragma once
+#include <string>
+
+#include "meta_common.hpp"
+
+#include "meta_qt/ui/control.hpp"
+#include "meta_qt/ui/glide.hpp"
+
+namespace meta::qt::industrial
+{
+
+/** @brief Label plus sliding switch for a bool attribute.
+ *
+ * The industrial design's Toggle, second only to the float slider by volume.
+ *
+ * Deliberately built on the same Control/bind machinery as ParamSlider despite
+ * having no drag and no range -- if the binder needed special-casing for a
+ * control this simple, the abstraction would not be carrying its weight.
+ */
+class CheckRow : public Control<bool>
+{
+  Q_OBJECT
+
+public:
+  CheckRow(Attribute<bool> &attr, const RowContext &ctx, QWidget *parent = nullptr);
+
+  /// A bool always has a renderable state; nothing to decline.
+  static bool can_render(const Attribute<bool> &) { return true; }
+
+  bool get() const override { return value_; }
+  void set(const bool &value) override;
+
+  QSize sizeHint() const override;
+
+protected:
+  void paintEvent(QPaintEvent *event) override;
+  void mousePressEvent(QMouseEvent *event) override;
+  void mouseReleaseEvent(QMouseEvent *event) override;
+  void keyPressEvent(QKeyEvent *event) override;
+
+private:
+  QRect switch_rect() const;
+  void  toggle();
+
+  bool        value_ = false;
+  std::string label_;
+  std::string key_;
+
+  Glide *glide_ = nullptr; ///< knob travel, 0 = off, 1 = on
+  qreal  knob_ = 0.0;
+  bool   pressed_ = false;
+};
+
+} // namespace meta::qt::industrial

--- a/MetaUI/qt/include/meta_qt/designs/industrial/industrial.hpp
+++ b/MetaUI/qt/include/meta_qt/designs/industrial/industrial.hpp
@@ -1,0 +1,28 @@
+/* Copyright (c) 2026 Otto Link. Distributed under the terms of the GNU General
+   Public License. The full license is in the file LICENSE, distributed with
+   this software. */
+#pragma once
+#include <string>
+
+namespace meta::qt::industrial
+{
+
+/// Design name to pass to render_row() / DesignRegistry.
+inline constexpr char kDesignName[] = "industrial";
+
+/** @brief Register every industrial control with the DesignRegistry.
+ *
+ * Idempotent, so a host may call it unconditionally at startup.
+ *
+ * Only the widget types this design actually implements are registered.
+ * Everything else resolves to nothing and falls back to the stock renderer,
+ * which is what keeps a partial design a usable panel rather than a broken one.
+ *
+ * Note there is deliberately no "stock" design to register: an unknown design
+ * name finds no factories and every row falls back, so `design = "stock"` gives
+ * the unmodified Qt look for free. That makes A/B comparison a settings change
+ * rather than a build.
+ */
+void register_design();
+
+} // namespace meta::qt::industrial

--- a/MetaUI/qt/include/meta_qt/designs/industrial/param_slider.hpp
+++ b/MetaUI/qt/include/meta_qt/designs/industrial/param_slider.hpp
@@ -1,0 +1,92 @@
+/* Copyright (c) 2026 Otto Link. Distributed under the terms of the GNU General
+   Public License. The full license is in the file LICENSE, distributed with
+   this software. */
+#pragma once
+#include <string>
+
+#include "meta_common.hpp"
+
+#include "meta_qt/ui/control.hpp"
+#include "meta_qt/ui/glide.hpp"
+
+class QLineEdit;
+
+namespace meta::qt::industrial
+{
+
+/** @brief Label / rail / value-field row for a float attribute.
+ *
+ * The industrial design's SliderFloat, covering roughly 58% of the rows in a
+ * Hesiod node panel.
+ *
+ * Painting follows the state matrix strictly: the rail fill is *always* the
+ * group accent and never encodes state; only the label and value text change
+ * colour between default, modified and locked.
+ */
+class ParamSlider : public Control<float>
+{
+  Q_OBJECT
+
+public:
+  ParamSlider(Attribute<float> &attr, const RowContext &ctx, QWidget *parent = nullptr);
+
+  /** @brief Decline attributes with no usable range.
+   *
+   * A rail needs `max > min` to span. Without both keys meta::common::min/max
+   * return the numeric limits, which produces a rail no drag can meaningfully
+   * address -- so the row falls back to the stock spin box instead.
+   */
+  static bool can_render(const Attribute<float> &attr);
+
+  float get() const override { return value_; }
+  void  set(const float &value) override;
+
+  QSize sizeHint() const override;
+
+protected:
+  void paintEvent(QPaintEvent *event) override;
+  void resizeEvent(QResizeEvent *event) override;
+  void mousePressEvent(QMouseEvent *event) override;
+  void mouseMoveEvent(QMouseEvent *event) override;
+  void mouseReleaseEvent(QMouseEvent *event) override;
+  void mouseDoubleClickEvent(QMouseEvent *event) override;
+  void handle_wheel(QWheelEvent *event) override;
+  void on_state_changed() override;
+
+  /// Watches the value field's focus so its chrome can follow the edit state.
+  bool eventFilter(QObject *watched, QEvent *event) override;
+
+private:
+  // --- geometry, recomputed from the row's own width (not the window's)
+  int    label_width() const;
+  int    field_width() const;
+  QRect  rail_rect() const;
+  QRect  thumb_rect() const;
+
+  // --- value <-> normalised position
+  qreal to_norm(float value) const;
+  float from_norm(qreal t) const;
+
+  void  set_from_position(int x);
+  void  apply_norm(qreal t);
+  QString format_value(float value) const;
+  void  refresh_field();
+  void  restyle_field(bool editing = false);
+
+  float       min_ = 0.f;
+  float       max_ = 1.f;
+  float       value_ = 0.f;
+  bool        log_scale_ = false;
+  int         decimals_ = 2;
+  std::string label_;
+  std::string category_;
+  std::string key_; ///< attribute name, for the defaults lookup on reset
+
+  Glide     *glide_ = nullptr; ///< animates the displayed position, 0..1
+  qreal      norm_ = 0.0;      ///< what is painted; may lag value_ mid-glide
+  QLineEdit *field_ = nullptr;
+  bool       dragging_ = false;
+  bool       hovered_rail_ = false;
+};
+
+} // namespace meta::qt::industrial

--- a/MetaUI/qt/include/meta_qt/ui/binding.hpp
+++ b/MetaUI/qt/include/meta_qt/ui/binding.hpp
@@ -1,0 +1,134 @@
+/* Copyright (c) 2026 Otto Link. Distributed under the terms of the GNU General
+   Public License. The full license is in the file LICENSE, distributed with
+   this software. */
+#pragma once
+#include <cmath>
+
+#include <QSignalBlocker>
+
+#include "meta_common.hpp"
+
+#include "meta_qt/meta_widget.hpp"
+#include "meta_qt/ui/control.hpp"
+
+namespace meta::qt
+{
+
+/** @brief Equality used to decide whether a value differs from its default.
+ *
+ * Specialise for types where exact comparison is wrong. Floating point uses the
+ * 1e-4 tolerance the state matrix is defined in terms of.
+ */
+template <class T> struct ValueCompare
+{
+  static bool equal(const T &a, const T &b) { return a == b; }
+};
+
+template <> struct ValueCompare<float>
+{
+  static bool equal(float a, float b) { return std::fabs(a - b) <= 1e-4f; }
+};
+
+template <> struct ValueCompare<double>
+{
+  static bool equal(double a, double b) { return std::fabs(a - b) <= 1e-4; }
+};
+
+/** @brief Wire an attribute to a control, both directions.
+ *
+ * Written once per *type* and never per design. Every visual variant of a float
+ * control shares this function, so the races below are fixed in one place:
+ *
+ * - A model sync arriving mid-drag re-seats the value under the cursor and
+ *   drops the handle. Suppressed via Control::is_editing().
+ * - Writing the attribute notifies subscribers synchronously, which syncs back
+ *   into the control, which would re-emit. Broken with QSignalBlocker.
+ * - The subscription outliving the widget dereferences freed memory. It is
+ *   stored in MetaWidget::connection_, declared so it dies first.
+ *
+ * The control owns range clamping and metadata reading; this function knows
+ * neither, which is what keeps it type-generic.
+ *
+ * Note this does *not* decide when the host recomputes. It emits
+ * edit_started/value_changed/edit_ended on `host` and the host chooses which to
+ * act on -- that is where a live-update setting belongs.
+ */
+template <class T> void bind(Attribute<T> &attr, Control<T> &control, MetaWidget &host)
+{
+  const std::string key = attr.name();
+
+  // --- modified state, recomputed on every value change
+  auto refresh_modified = [&attr, &control, key]()
+  {
+    const auto &provider = control.context().default_value;
+    if (!provider)
+    {
+      control.set_modified(false);
+      return;
+    }
+
+    const std::any def = provider(key);
+    if (!def.has_value())
+    {
+      control.set_modified(false);
+      return;
+    }
+
+    try
+    {
+      control.set_modified(!ValueCompare<T>::equal(attr.value(), std::any_cast<T>(def)));
+    }
+    catch (const std::bad_any_cast &)
+    {
+      control.set_modified(false);
+    }
+  };
+
+  // --- control -> model
+  QObject::connect(&control,
+                   &ControlBase::edit_started,
+                   &host,
+                   [&host]() { Q_EMIT host.edit_started(); });
+
+  QObject::connect(&control,
+                   &ControlBase::value_changed,
+                   &host,
+                   [&attr, &control, &host, refresh_modified]()
+                   {
+                     attr.set_from_any(control.get());
+                     refresh_modified();
+                     Q_EMIT host.value_changed();
+                   });
+
+  QObject::connect(&control,
+                   &ControlBase::edit_ended,
+                   &host,
+                   [&attr, &control, &host, refresh_modified]()
+                   {
+                     attr.set_from_any(control.get());
+                     refresh_modified();
+                     Q_EMIT host.edit_ended();
+                   });
+
+  // --- model -> control
+  host.set_sync_from_model(
+      [&attr, &control, refresh_modified]()
+      {
+        // A sync must never fight an edit in progress.
+        if (control.is_editing()) return;
+
+        const QSignalBlocker blocker(&control);
+        control.set(attr.value());
+        refresh_modified();
+      });
+
+  // Dies with the widget: connection_ is declared before anything it captures.
+  host.connection_ = attr.value_changed.subscribe([&host](const T &)
+                                                  { host.sync_widget_from_model(); });
+
+  // --- initial state
+  control.set_locked(meta::common::try_get<bool>(attr, meta::keys::ui::read_only, false));
+  refresh_modified();
+}
+
+} // namespace meta::qt

--- a/MetaUI/qt/include/meta_qt/ui/control.hpp
+++ b/MetaUI/qt/include/meta_qt/ui/control.hpp
@@ -1,0 +1,136 @@
+/* Copyright (c) 2026 Otto Link. Distributed under the terms of the GNU General
+   Public License. The full license is in the file LICENSE, distributed with
+   this software. */
+#pragma once
+#include <any>
+#include <functional>
+#include <string>
+
+#include <QWidget>
+
+#include "meta_qt/ui/theme.hpp"
+
+class QWheelEvent;
+
+namespace meta::qt
+{
+
+/** @brief What a control is handed at construction.
+ *
+ * Everything a control needs that is not on the attribute itself. Kept as a
+ * struct so adding a field later does not touch every control constructor.
+ */
+struct RowContext
+{
+  const Theme *theme = nullptr;
+
+  /** @brief Default value for an attribute key, for the modified/default state.
+   *
+   * Supplied by the host, because "modified" means `|value - default| > 1e-4`
+   * and Meta attributes do not carry their default. An empty std::any (or an
+   * unset provider) means "unknown", which is reported as *not* modified --
+   * a panel that wrongly shows everything as modified is worse than one that
+   * shows nothing as modified.
+   */
+  std::function<std::any(const std::string &key)> default_value;
+};
+
+/** @brief Non-templated base for every attribute control.
+ *
+ * Carries the parts that cannot live in a template (Q_OBJECT) and the parts
+ * every control must get right regardless of design. Two behaviours are
+ * enforced here rather than documented, because both have been re-broken:
+ *
+ * - Wheel events are ignored unless the control has focus, so scrolling the
+ *   panel cannot silently change whatever value sits under the cursor.
+ *   wheelEvent() is final; override handle_wheel() instead.
+ * - is_editing() is set by begin_edit()/end_edit() alongside the matching
+ *   signals, so a control cannot raise one without the other. The binder reads
+ *   it to stop a model sync from re-seating a value mid-drag.
+ */
+class ControlBase : public QWidget
+{
+  Q_OBJECT
+
+public:
+  explicit ControlBase(const RowContext &ctx, QWidget *parent = nullptr);
+
+  const Theme      &theme() const { return *theme_; }
+  const RowContext &context() const { return ctx_; }
+
+  /// True between begin_edit() and end_edit(); a sync must not fight this.
+  bool is_editing() const { return editing_; }
+
+  bool is_locked() const { return locked_; }
+  void set_locked(bool locked);
+
+  /// `|value - default| > 1e-4`. Drives text colour only -- never the fill.
+  bool is_modified() const { return modified_; }
+  void set_modified(bool modified);
+
+signals:
+  void edit_started();
+  void value_changed();
+  void edit_ended();
+
+protected:
+  /// Enter the editing state and emit edit_started(). Idempotent.
+  void begin_edit();
+
+  /// Leave the editing state and emit edit_ended(). Idempotent.
+  void end_edit();
+
+  /// Emit value_changed(). Does not alter the editing state.
+  void notify_value_changed();
+
+  /// Called when the state matrix changed; repaint or restyle here.
+  virtual void on_state_changed() { update(); }
+
+  /** @brief Elide `text` to `width`, surfacing the full text as a tooltip.
+   *
+   * Attribute labels routinely overrun the label column. A hard cut is
+   * indistinguishable from a genuinely short name, so elide and let the
+   * tooltip carry the rest -- but never shadow a tooltip the host already set
+   * from ui.tooltip metadata.
+   */
+  QString elide_label(const QString &text, const QFont &font, int width);
+
+  /// Override this rather than wheelEvent(); only called when focused.
+  virtual void handle_wheel(QWheelEvent *event);
+
+  void wheelEvent(QWheelEvent *event) final;
+
+private:
+  RowContext   ctx_;
+  const Theme *theme_ = nullptr;
+  bool         editing_ = false;
+  bool         locked_ = false;
+  bool         modified_ = false;
+};
+
+/** @brief Typed control interface.
+ *
+ * Typed rather than QVariant-based so glm and Meta types need no metatype
+ * registration, and so a mismatched registration fails to compile instead of
+ * failing at runtime.
+ *
+ * Implementations are constructed as `ControlT(Attribute<T> &, const RowContext
+ * &, QWidget *)` -- see make_row_factory(). A control reads its own metadata
+ * (label, range, format, log scale); the binder deliberately knows none of it.
+ */
+template <class T> class Control : public ControlBase
+{
+public:
+  using ControlBase::ControlBase;
+
+  virtual T get() const = 0;
+
+  /** @brief Seat a value coming from the model.
+   *
+   * The binder already suppresses this during an edit, so implementations need
+   * not re-check is_editing().
+   */
+  virtual void set(const T &value) = 0;
+};
+
+} // namespace meta::qt

--- a/MetaUI/qt/include/meta_qt/ui/design_registry.hpp
+++ b/MetaUI/qt/include/meta_qt/ui/design_registry.hpp
@@ -1,0 +1,129 @@
+/* Copyright (c) 2026 Otto Link. Distributed under the terms of the GNU General
+   Public License. The full license is in the file LICENSE, distributed with
+   this software. */
+#pragma once
+#include <functional>
+#include <map>
+#include <string>
+#include <typeindex>
+#include <vector>
+
+#include <QLayout>
+
+#include "meta/core/abstract_attribute.hpp"
+
+#include "meta_qt/meta_widget.hpp"
+#include "meta_qt/ui/binding.hpp"
+#include "meta_qt/ui/control.hpp"
+
+namespace meta::qt
+{
+
+/// Builds a fully bound row for one attribute, or nullptr if it cannot.
+using RowFactory = std::function<
+    MetaWidget *(AbstractAttribute &, const RowContext &, QWidget *)>;
+
+/// Matches any widget_type for a given C++ type.
+inline constexpr char kAnyWidgetType[] = "*";
+
+/** @brief Construct-and-bind a control of type `ControlT` for attribute type `T`.
+ *
+ * The uniform control constructor is
+ * `ControlT(Attribute<T> &, const RowContext &, QWidget *)`. A control reads its
+ * own metadata; binding is identical for every control of a type and lives in
+ * bind().
+ *
+ * A control must also provide `static bool can_render(const Attribute<T> &)`.
+ * Returning false declines the attribute and the row falls back to the stock
+ * renderer -- the required escape hatch for metadata a design cannot honour,
+ * such as a rail with no min/max to span. Making it part of the contract means
+ * a control cannot forget to check and silently render a [0, 0] range instead.
+ */
+template <class T, class ControlT> RowFactory make_row_factory()
+{
+  return [](AbstractAttribute &abstract_attr,
+            const RowContext  &ctx,
+            QWidget           *parent) -> MetaWidget *
+  {
+    auto &attr = static_cast<Attribute<T> &>(abstract_attr);
+
+    if (!ControlT::can_render(attr)) return nullptr;
+
+    MetaWidget *host = make_meta_widget_vbox(parent);
+    auto       *control = new ControlT(attr, ctx, host);
+
+    host->layout()->addWidget(control);
+    bind<T>(attr, *control, *host);
+
+    return host;
+  };
+}
+
+/** @brief Maps (design, C++ type, widget_type) to a row factory.
+ *
+ * This is what makes a second visual design a registration rather than an edit
+ * to a dispatch function. The stock renderer resolves type and widget_type
+ * through two hardcoded if-chains, so every new design or type meant editing
+ * shared code; here they are table entries.
+ *
+ * Lookup order for a given design:
+ *   1. exact (type, widget_type)
+ *   2. (type, "*")
+ *   3. miss -- the caller falls back to the stock meta::qt::render()
+ *
+ * That fallback is deliberate and load-bearing: it is what lets a design cover
+ * three widget types and still leave a completely usable panel.
+ */
+class DesignRegistry
+{
+public:
+  static DesignRegistry &instance();
+
+  /// Register a factory. Replaces any existing entry for the same key.
+  void add(const std::string &design,
+           std::type_index    type,
+           const std::string &widget_type,
+           RowFactory         factory);
+
+  /// Convenience wrapper around add() + make_row_factory().
+  template <class T, class ControlT>
+  void register_control(const std::string &design, const std::string &widget_type)
+  {
+    add(design, std::type_index(typeid(T)), widget_type, make_row_factory<T, ControlT>());
+  }
+
+  /** @brief Build a row for `p_attr` using `design`.
+   *
+   * Returns nullptr when the design has nothing registered for this attribute,
+   * which the caller should treat as "use the stock renderer" rather than as an
+   * error. See render_row().
+   */
+  MetaWidget *render(AbstractAttribute *p_attr,
+                     const std::string &design,
+                     const RowContext  &ctx,
+                     QWidget           *parent = nullptr) const;
+
+  bool has_design(const std::string &design) const;
+
+  /// Registered design names, for a settings UI.
+  std::vector<std::string> designs() const;
+
+private:
+  DesignRegistry() = default;
+
+  using Key = std::pair<std::type_index, std::string>;
+
+  std::map<std::string, std::map<Key, RowFactory>> factories_;
+};
+
+/** @brief Render one attribute, falling back to the stock renderer on a miss.
+ *
+ * The single entry point a panel should call. Keeps the fallback in one place
+ * so a partially ported design cannot leave holes in a panel.
+ */
+MetaWidget *render_row(AbstractAttribute *p_attr,
+                       const std::string &design,
+                       const RowContext  &ctx,
+                       QWidget           *parent = nullptr);
+
+} // namespace meta::qt

--- a/MetaUI/qt/include/meta_qt/ui/glide.hpp
+++ b/MetaUI/qt/include/meta_qt/ui/glide.hpp
@@ -1,0 +1,54 @@
+/* Copyright (c) 2026 Otto Link. Distributed under the terms of the GNU General
+   Public License. The full license is in the file LICENSE, distributed with
+   this software. */
+#pragma once
+#include <QObject>
+#include <QVariantAnimation>
+
+namespace meta::qt
+{
+
+/** @brief A retargetable eased value, used wherever a control must not snap.
+ *
+ * Exists as a type rather than as a loose QVariantAnimation because two
+ * mistakes around animated values are easy to make and hard to spot:
+ *
+ * - A running QVariantAnimation ignores a new end value. Retargeting without
+ *   stopping first silently does nothing, which reads as "the reset button is
+ *   broken". to() always stops first.
+ * - Committing a value immediately after starting an animation commits the
+ *   *old* value, because the animation has not produced the new one yet. The
+ *   commit belongs on finished(), which is why that signal carries the value.
+ */
+class Glide : public QObject
+{
+  Q_OBJECT
+
+public:
+  explicit Glide(int duration_ms, QObject *parent = nullptr);
+
+  /// Animate towards `target`. Safe to call while already running.
+  void to(qreal target);
+
+  /// Move immediately, cancelling any running animation. Emits tick(), not finished().
+  void jump(qreal value);
+
+  qreal current() const { return current_; }
+
+  bool running() const;
+
+  void set_duration(int ms);
+
+signals:
+  /// Emitted on every animation frame and on jump().
+  void tick(qreal value);
+
+  /// Emitted once the animation settles. Carry commits on this, never earlier.
+  void finished(qreal value);
+
+private:
+  QVariantAnimation animation_;
+  qreal             current_ = 0.0;
+};
+
+} // namespace meta::qt

--- a/MetaUI/qt/include/meta_qt/ui/theme.hpp
+++ b/MetaUI/qt/include/meta_qt/ui/theme.hpp
@@ -1,0 +1,199 @@
+/* Copyright (c) 2026 Otto Link. Distributed under the terms of the GNU General
+   Public License. The full license is in the file LICENSE, distributed with
+   this software. */
+#pragma once
+#include <map>
+#include <string>
+#include <vector>
+
+#include <QColor>
+#include <QFont>
+
+namespace meta::qt
+{
+
+/** @brief A monospaced font that exists on this platform.
+ *
+ * Naming a family directly is a portability trap: `Menlo` is macOS-only and
+ * elsewhere silently degrades every numeric readout to a proportional face,
+ * which looks like a layout bug rather than a missing font. The result is
+ * resolved once and cached.
+ */
+QFont mono_font(int pixel_size);
+
+/// The UI sans face. No family override -- the system font is correct here.
+QFont ui_font(int pixel_size, bool bold = false, qreal letter_spacing = 0.0);
+
+/** @brief Geometry and timing constants for a design.
+ *
+ * Separate from the palette because a colourway swap changes colours only,
+ * while a design swap may change both.
+ */
+struct Metrics
+{
+  // --- rows
+  int   row_height = 36;
+  int   label_min_width = 90;
+  int   label_max_width = 168;
+  qreal label_width_ratio = 0.3;
+  int   gap = 12;
+  int   narrow_threshold = 430; ///< row width below which the narrow branch applies
+
+  // --- value field
+  int value_field_width = 74;
+  int value_field_width_narrow = 64;
+  int value_field_height = 24;
+
+  // --- rail and thumb
+  int rail_height = 6;
+  int rail_radius = 1;
+  int thumb_width = 10;
+  int thumb_height = 18;
+
+  // --- switch rows
+  int check_row_height = 28;
+  int switch_width = 36;
+  int switch_height = 18;
+  int knob_size = 12;
+  int knob_inset = 3;
+
+  // --- section
+  int section_header_height = 38;
+  int section_body_padding_x = 20;
+  int section_body_padding_x_narrow = 12;
+  int section_body_padding_y = 12;
+  int section_row_spacing = 10;
+
+  // --- shared
+  int radius = 2;
+  int glide_ms = 260;   ///< value glide; nothing snaps
+  int switch_ms = 150;  ///< switch knob slide
+  int section_ms = 200; ///< disclosure rotation
+};
+
+/** @brief A complete colourway plus geometry.
+ *
+ * A value type, deliberately: two panels may hold different themes, a theme is
+ * trivially testable, and swapping one is an assignment rather than a mutation
+ * of process-wide state. Controls receive a `const Theme &` that outlives them
+ * (owned by the ThemeRegistry) and read it at paint time.
+ *
+ * Derived colours are exposed as *functions* rather than baked swatches, because
+ * the formula is the thing that must survive an accent change.
+ */
+struct Theme
+{
+  std::string name = "industrial-dark";
+
+  // --- surfaces
+  QColor page{"#2b2b2b"};
+  QColor bar{"#262626"};
+  QColor section_header{"#333333"};
+  QColor section_header_hover{"#383838"};
+  QColor section_header_press{"#303030"};
+  QColor rail_well{"#1c1c1c"};
+  QColor field{"#1f1f1f"};
+  QColor field_hover{"#262626"};
+  QColor field_editing{"#161616"};
+  QColor switch_track_off{"#1f1f1f"};
+
+  // --- hairlines and bevels
+  QColor bevel_top{"#3d3d3d"};
+  QColor bevel_bottom{"#232323"};
+  QColor hairline{"#1a1a1a"};
+  QColor rail_well_border{"#161616"};
+  QColor field_border{"#4a4a4a"};
+  QColor field_border_hover{"#5a5a5a"};
+
+  // --- ink. Only text encodes state; see state_ink().
+  QColor ink_primary{"#e0e0e0"};
+  QColor ink_section_title{"#d0d0d0"};
+  QColor ink_secondary{"#9a9a9a"}; ///< value at default
+  QColor ink_dim{"#8a8a8a"};
+  QColor ink_locked{"#606060"};
+  QColor ink_modified{"#ffffff"};
+  QColor ink_icon{"#c9c9c9"};
+
+  // --- metal
+  QColor thumb_top{"#d6d6d6"};
+  QColor thumb_bottom{"#a8a8a8"};
+  QColor thumb_border{"#1a1a1a"};
+  QColor thumb_grip{"#5f5f5f"};
+  QColor knob_on_top{"#e8e8e8"};
+  QColor knob_on_bottom{"#b8b8b8"};
+  QColor knob_off_top{"#8a8a8a"};
+  QColor knob_off_bottom{"#6a6a6a"};
+
+  // --- accent
+  QColor accent{"#e08a2e"};
+
+  /// Per-group accents, keyed by attribute category. Falls back to `accent`.
+  std::map<std::string, QColor> group_accents = {{"Erosion", QColor("#cfa143")},
+                                                 {"Downcutting", QColor("#3aa899")},
+                                                 {"Scale", QColor("#7d9cc0")},
+                                                 {"Flow", QColor("#c06478")},
+                                                 {"Selective", QColor("#a08bb8")},
+                                                 {"Other", QColor("#9a9a9a")}};
+
+  // --- derived-colour opacities. Port the formula, not the swatch.
+  qreal rail_fill_alpha = 0.9;
+  qreal locked_rail_fill_alpha = 0.3;
+  qreal locked_thumb_alpha = 0.4;
+  qreal switch_track_on_darker = 1.7;
+
+  Metrics metrics;
+
+  // --- derived colours
+
+  /// Accent for an attribute category, falling back to the chrome accent.
+  QColor group_accent(const std::string &category) const;
+
+  /// Rail fill: always the group accent, never a state colour.
+  QColor rail_fill(const std::string &category, bool locked = false) const;
+
+  /// Switch track when on.
+  QColor switch_track_on() const;
+
+  /** @brief The one colour state is allowed to change.
+   *
+   * @param modified `|value - default| > 1e-4`, not "changed since opened".
+   */
+  QColor state_ink(bool modified, bool locked) const;
+};
+
+/** @brief Owns the built-in themes and any registered by a host.
+ *
+ * Themes are resolved once at construction time. Switching requires a restart:
+ * controls cache brushes and pixmaps derived from the theme, and invalidating
+ * those on every theme change would cost more than the feature is worth until a
+ * second colourway actually exists.
+ */
+class ThemeRegistry
+{
+public:
+  static ThemeRegistry &instance();
+
+  /// Register a theme under `theme.name`, replacing any existing entry.
+  void add(Theme theme);
+
+  /** @brief Look up a theme by name.
+   *
+   * Returns the default theme when `name` is unknown, so a stale settings file
+   * degrades to something usable rather than to an unpainted panel.
+   */
+  const Theme &get(const std::string &name) const;
+
+  /// Names of every registered theme, for a settings UI.
+  std::vector<std::string> names() const;
+
+  /// The theme returned when a lookup misses.
+  const Theme &fallback() const;
+
+private:
+  ThemeRegistry();
+
+  std::map<std::string, Theme> themes_;
+  std::string                  fallback_name_;
+};
+
+} // namespace meta::qt

--- a/MetaUI/qt/src/container_widget/container_widget.cpp
+++ b/MetaUI/qt/src/container_widget/container_widget.cpp
@@ -63,9 +63,21 @@ void insert_attribute(CategoryNode      &root,
   node->attributes.push_back(attr);
 }
 
-void render_flat(CategoryNode              &node,
-                 QVBoxLayout               *layout,
-                 std::vector<MetaWidget *> &collected_widgets)
+namespace
+{
+
+/// The stock renderer unless the caller supplied a design-aware one.
+MetaWidget *build_row(const AttributeRowRenderer &row_renderer, AbstractAttribute *p_attr)
+{
+  return row_renderer ? row_renderer(p_attr) : qt::render(p_attr);
+}
+
+} // namespace
+
+void render_flat(CategoryNode               &node,
+                 QVBoxLayout                *layout,
+                 std::vector<MetaWidget *>  &collected_widgets,
+                 const AttributeRowRenderer &row_renderer)
 {
   Logger::log()->trace("container_widget::render_flat");
 
@@ -74,7 +86,7 @@ void render_flat(CategoryNode              &node,
     Logger::log()->trace("container_widget::render_flat: '{}'",
                          p_attr ? p_attr->name() : std::string("null"));
 
-    MetaWidget *w = qt::render(p_attr);
+    MetaWidget *w = build_row(row_renderer, p_attr);
 
     if (w)
     {
@@ -91,7 +103,7 @@ void render_flat(CategoryNode              &node,
   }
 
   for (const auto &name : node.children_order)
-    render_flat(*node.children.at(name), layout, collected_widgets);
+    render_flat(*node.children.at(name), layout, collected_widgets, row_renderer);
 }
 
 void render_category(AttributeContainer        &container,
@@ -99,7 +111,8 @@ void render_category(AttributeContainer        &container,
                      QVBoxLayout               *parent_layout,
                      std::vector<MetaWidget *> &collected_widgets,
                      std::vector<std::pair<CollapsibleSection *, std::string>>
-                         &collected_sections)
+                                                &collected_sections,
+                     const AttributeRowRenderer &row_renderer)
 {
   Logger::log()->trace("container_widget::render_category: '{}'", node.name);
 
@@ -144,7 +157,7 @@ void render_category(AttributeContainer        &container,
     Logger::log()->trace("container_widget::render_category: '{}'",
                          p_attr ? p_attr->name() : std::string("null"));
 
-    MetaWidget *w = qt::render(p_attr);
+    MetaWidget *w = build_row(row_renderer, p_attr);
 
     if (w) // avoid 'None' type widgets
     {
@@ -165,7 +178,8 @@ void render_category(AttributeContainer        &container,
                     *node.children.at(name),
                     current_layout,
                     collected_widgets,
-                    collected_sections);
+                    collected_sections,
+                    row_renderer);
 }
 
 void render_category_merged(
@@ -175,7 +189,8 @@ void render_category_merged(
     std::vector<MetaWidget *> &collected_widgets,
     std::vector<std::pair<CollapsibleSection *, std::string>>
                                     &collected_sections,
-    const std::optional<std::regex> &collapse_regex)
+    const std::optional<std::regex> &collapse_regex,
+    const AttributeRowRenderer      &row_renderer)
 {
   Logger::log()->trace("container_widget::render_category_merged");
 
@@ -241,7 +256,7 @@ void render_category_merged(
       Logger::log()->trace("container_widget::render_category_merged: '{}'",
                            p_attr ? p_attr->name() : std::string("null"));
 
-      MetaWidget *w = qt::render(p_attr);
+      MetaWidget *w = build_row(row_renderer, p_attr);
 
       if (w) // 'None' widget is possible
       {
@@ -265,7 +280,8 @@ void render_category_merged(
                            layout,
                            collected_widgets,
                            collected_sections,
-                           collapse_regex);
+                           collapse_regex,
+                           row_renderer);
 }
 
 MetaWidget *render(AttributeContainer    &container,
@@ -338,7 +354,8 @@ MetaWidget *render(AttributeContainer    &container,
                     root,
                     layout,
                     collected_widgets,
-                    collected_sections);
+                    collected_sections,
+                    options.row_renderer);
     break;
 
   case CategoryPolicy::CP_MERGED:
@@ -348,21 +365,23 @@ MetaWidget *render(AttributeContainer    &container,
                            layout,
                            collected_widgets,
                            collected_sections,
-                           options.collapse_regex);
+                           options.collapse_regex,
+                           options.row_renderer);
     break;
 
   case CategoryPolicy::CP_SMART:
     Logger::log()->trace("container_widget::render: smart mode");
 
     if (has_no_categorys)
-      render_flat(root, layout, collected_widgets);
+      render_flat(root, layout, collected_widgets, options.row_renderer);
     else
       render_category_merged(container,
                              root,
                              layout,
                              collected_widgets,
                              collected_sections,
-                             options.collapse_regex);
+                             options.collapse_regex,
+                             options.row_renderer);
     break;
 
 #pragma GCC diagnostic push
@@ -370,7 +389,9 @@ MetaWidget *render(AttributeContainer    &container,
 
   case CategoryPolicy::CP_FLAT:
     Logger::log()->trace("container_widget::render: flat mode");
-  default: render_flat(root, layout, collected_widgets); break;
+  default:
+    render_flat(root, layout, collected_widgets, options.row_renderer);
+    break;
 
 #pragma GCC diagnostic pop
   }

--- a/MetaUI/qt/src/designs/industrial/check_row.cpp
+++ b/MetaUI/qt/src/designs/industrial/check_row.cpp
@@ -1,0 +1,170 @@
+/* Copyright (c) 2026 Otto Link. Distributed under the terms of the GNU General
+   Public License. The full license is in the file LICENSE, distributed with
+   this software. */
+#include "meta_qt/designs/industrial/check_row.hpp"
+
+#include <cmath>
+
+#include <QKeyEvent>
+#include <QLinearGradient>
+#include <QMouseEvent>
+#include <QPainter>
+
+namespace meta::qt::industrial
+{
+
+CheckRow::CheckRow(Attribute<bool> &attr, const RowContext &ctx, QWidget *parent)
+    : Control<bool>(ctx, parent)
+{
+  key_ = attr.name();
+  label_ = meta::common::label(attr);
+  value_ = attr.value();
+  knob_ = value_ ? 1.0 : 0.0;
+
+  setFixedHeight(theme().metrics.check_row_height);
+  setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Fixed);
+
+  glide_ = new Glide(theme().metrics.switch_ms, this);
+  connect(glide_,
+          &Glide::tick,
+          this,
+          [this](qreal t)
+          {
+            knob_ = t;
+            update();
+          });
+  glide_->jump(knob_);
+}
+
+void CheckRow::set(const bool &value)
+{
+  if (value_ == value) return;
+  value_ = value;
+  glide_->to(value_ ? 1.0 : 0.0);
+  update();
+}
+
+QSize CheckRow::sizeHint() const
+{
+  const Metrics &m = theme().metrics;
+  return QSize(m.label_min_width + m.gap + m.switch_width, m.check_row_height);
+}
+
+QRect CheckRow::switch_rect() const
+{
+  const Metrics &m = theme().metrics;
+  return QRect(width() - m.switch_width,
+               (height() - m.switch_height) / 2,
+               m.switch_width,
+               m.switch_height);
+}
+
+void CheckRow::paintEvent(QPaintEvent *)
+{
+  QPainter painter(this);
+  painter.setRenderHint(QPainter::Antialiasing, true);
+
+  const Theme   &t = theme();
+  const Metrics &m = t.metrics;
+  const bool     locked = is_locked();
+
+  // --- label
+  QFont label_font = ui_font(12, false, 1.0);
+  label_font.setCapitalization(QFont::AllUppercase);
+  painter.setFont(label_font);
+  painter.setPen(t.state_ink(is_modified(), locked));
+  const int label_w = width() - m.switch_width - m.gap;
+  painter.drawText(QRect(0, 0, label_w, height()),
+                   Qt::AlignLeft | Qt::AlignVCenter,
+                   elide_label(QString::fromStdString(label_), label_font, label_w));
+
+  painter.setOpacity(locked ? t.locked_thumb_alpha : 1.0);
+
+  // --- track. On uses the accent, consistent with the rail: fills are accent,
+  // never a state colour.
+  const QRect track = switch_rect();
+  QColor      track_color = t.switch_track_off;
+  if (knob_ > 0.0)
+  {
+    QColor on = t.switch_track_on();
+    // blend across the travel so the track follows the knob rather than
+    // snapping at the midpoint
+    track_color = QColor::fromRgbF(
+        t.switch_track_off.redF() * (1.0 - knob_) + on.redF() * knob_,
+        t.switch_track_off.greenF() * (1.0 - knob_) + on.greenF() * knob_,
+        t.switch_track_off.blueF() * (1.0 - knob_) + on.blueF() * knob_);
+  }
+
+  painter.setPen(QPen(t.hairline, 1));
+  painter.setBrush(track_color);
+  painter.drawRoundedRect(QRectF(track).adjusted(0.5, 0.5, -0.5, -0.5),
+                          m.radius,
+                          m.radius);
+
+  // --- knob
+  const int travel = m.switch_width - m.knob_size - 2 * m.knob_inset;
+  const QRect knob(track.x() + m.knob_inset + int(std::round(knob_ * travel)),
+                   track.y() + m.knob_inset,
+                   m.knob_size,
+                   m.switch_height - 2 * m.knob_inset);
+
+  QLinearGradient metal(knob.topLeft(), knob.bottomLeft());
+  metal.setColorAt(0.0, value_ ? t.knob_on_top : t.knob_off_top);
+  metal.setColorAt(1.0, value_ ? t.knob_on_bottom : t.knob_off_bottom);
+
+  painter.setPen(QPen(t.thumb_border, 1));
+  painter.setBrush(metal);
+  painter.drawRoundedRect(QRectF(knob).adjusted(0.5, 0.5, -0.5, -0.5),
+                          m.radius,
+                          m.radius);
+
+  painter.setOpacity(1.0);
+}
+
+void CheckRow::mousePressEvent(QMouseEvent *event)
+{
+  if (is_locked() || event->button() != Qt::LeftButton)
+  {
+    event->ignore();
+    return;
+  }
+
+  setFocus(Qt::MouseFocusReason);
+  pressed_ = true;
+}
+
+void CheckRow::mouseReleaseEvent(QMouseEvent *event)
+{
+  if (!pressed_) return;
+  pressed_ = false;
+
+  // The whole row is the hit target, not just the switch.
+  if (rect().contains(event->pos())) toggle();
+}
+
+void CheckRow::keyPressEvent(QKeyEvent *event)
+{
+  if (!is_locked() && (event->key() == Qt::Key_Space || event->key() == Qt::Key_Return))
+  {
+    toggle();
+    event->accept();
+    return;
+  }
+
+  Control<bool>::keyPressEvent(event);
+}
+
+void CheckRow::toggle()
+{
+  value_ = !value_;
+  glide_->to(value_ ? 1.0 : 0.0);
+  update();
+
+  // A discrete control has no drag, so the whole edit is one instant: the
+  // binder still sees a well-formed started/changed/ended sequence.
+  begin_edit();
+  notify_value_changed();
+  end_edit();
+}
+
+} // namespace meta::qt::industrial

--- a/MetaUI/qt/src/designs/industrial/industrial.cpp
+++ b/MetaUI/qt/src/designs/industrial/industrial.cpp
@@ -1,0 +1,31 @@
+/* Copyright (c) 2026 Otto Link. Distributed under the terms of the GNU General
+   Public License. The full license is in the file LICENSE, distributed with
+   this software. */
+#include "meta_qt/designs/industrial/industrial.hpp"
+
+#include "meta_qt/designs/industrial/check_row.hpp"
+#include "meta_qt/designs/industrial/param_slider.hpp"
+#include "meta_qt/ui/design_registry.hpp"
+
+namespace meta::qt::industrial
+{
+
+void register_design()
+{
+  static bool registered = false;
+  if (registered) return;
+  registered = true;
+
+  DesignRegistry &registry = DesignRegistry::instance();
+
+  // --- float: 58% of the rows in a Hesiod node panel
+  registry.register_control<float, ParamSlider>(kDesignName, "SliderFloat");
+
+  // --- bool: 14%. Both presets map to the same control for now; BinaryButtons
+  // wants its own A/B chip pair, which is a separate design entry rather than a
+  // branch inside CheckRow.
+  registry.register_control<bool, CheckRow>(kDesignName, "Toggle");
+  registry.register_control<bool, CheckRow>(kDesignName, "Checkbox");
+}
+
+} // namespace meta::qt::industrial

--- a/MetaUI/qt/src/designs/industrial/param_slider.cpp
+++ b/MetaUI/qt/src/designs/industrial/param_slider.cpp
@@ -1,0 +1,442 @@
+/* Copyright (c) 2026 Otto Link. Distributed under the terms of the GNU General
+   Public License. The full license is in the file LICENSE, distributed with
+   this software. */
+#include "meta_qt/designs/industrial/param_slider.hpp"
+
+#include <algorithm>
+#include <cmath>
+
+#include <QLinearGradient>
+#include <QLineEdit>
+#include <QMouseEvent>
+#include <QPainter>
+#include <QResizeEvent>
+#include <QWheelEvent>
+
+namespace meta::qt::industrial
+{
+
+namespace
+{
+constexpr qreal kLogFloor = 1e-6; ///< below this a log mapping is undefined
+}
+
+ParamSlider::ParamSlider(Attribute<float> &attr, const RowContext &ctx, QWidget *parent)
+    : Control<float>(ctx, parent)
+{
+  key_ = attr.name();
+  label_ = meta::common::label(attr);
+  category_ = meta::common::category(attr);
+  min_ = meta::common::min(attr);
+  max_ = meta::common::max(attr);
+  log_scale_ = meta::common::try_get<bool>(attr, meta::keys::ui::log_scale, false);
+  decimals_ = meta::common::try_get_format_decimals(meta::common::format(attr));
+
+  // A log mapping needs a strictly positive lower bound; fall back to linear
+  // rather than producing NaNs across the whole rail.
+  if (log_scale_ && min_ <= kLogFloor) log_scale_ = false;
+
+  value_ = std::clamp(attr.value(), min_, max_);
+  norm_ = to_norm(value_);
+
+  setFixedHeight(theme().metrics.row_height);
+  setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Fixed);
+
+  glide_ = new Glide(theme().metrics.glide_ms, this);
+  connect(glide_,
+          &Glide::tick,
+          this,
+          [this](qreal t)
+          {
+            norm_ = t;
+            value_ = from_norm(t);
+            refresh_field();
+            update();
+          });
+
+  // The commit rides the animation's completion. Emitting it when the glide
+  // starts would publish the value the control still held a frame ago.
+  connect(glide_,
+          &Glide::finished,
+          this,
+          [this](qreal t)
+          {
+            norm_ = t;
+            value_ = from_norm(t);
+            refresh_field();
+            update();
+            notify_value_changed();
+            end_edit();
+          });
+  glide_->jump(norm_);
+
+  field_ = new QLineEdit(this);
+  field_->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
+  field_->setFrame(false);
+  field_->setFont(mono_font(13));
+  field_->installEventFilter(this);
+  refresh_field();
+  restyle_field();
+
+  connect(field_,
+          &QLineEdit::editingFinished,
+          this,
+          [this]()
+          {
+            bool        ok = false;
+            const float typed = field_->text().toFloat(&ok);
+            if (!ok)
+            {
+              refresh_field(); // reject silently, restore the real value
+              return;
+            }
+
+            begin_edit();
+            glide_->to(to_norm(std::clamp(typed, min_, max_)));
+          });
+
+  connect(field_, &QLineEdit::textEdited, this, [this]() { restyle_field(true); });
+}
+
+bool ParamSlider::can_render(const Attribute<float> &attr)
+{
+  // contains_all_keys() is non-const, so probe with find() instead of taking a
+  // mutable reference just to ask a question.
+  const auto &metadata = attr.metadata();
+  if (!metadata.find(meta::keys::constraints::min) ||
+      !metadata.find(meta::keys::constraints::max))
+    return false;
+
+  return meta::common::max(attr) > meta::common::min(attr);
+}
+
+void ParamSlider::set(const float &value)
+{
+  const float clamped = std::clamp(value, min_, max_);
+
+  // jump() emits tick(), which derives value_ back out of the normalised
+  // position -- lossy under a log mapping. Seat the authoritative value after.
+  glide_->jump(to_norm(clamped)); // a model sync seats immediately, no glide
+  value_ = clamped;
+
+  refresh_field();
+  update();
+}
+
+QSize ParamSlider::sizeHint() const
+{
+  return QSize(theme().metrics.label_min_width + 200, theme().metrics.row_height);
+}
+
+// --- geometry
+
+int ParamSlider::label_width() const
+{
+  const Metrics &m = theme().metrics;
+  return int(std::clamp<qreal>(width() * m.label_width_ratio,
+                               m.label_min_width,
+                               m.label_max_width));
+}
+
+int ParamSlider::field_width() const
+{
+  const Metrics &m = theme().metrics;
+  // The narrow branch keys off this row's own width, not the window's.
+  return width() < m.narrow_threshold ? m.value_field_width_narrow
+                                      : m.value_field_width;
+}
+
+QRect ParamSlider::rail_rect() const
+{
+  const Metrics &m = theme().metrics;
+  const int      x0 = label_width() + m.gap;
+  const int      x1 = width() - field_width() - m.gap;
+  const int      y = (height() - m.rail_height) / 2;
+  return QRect(x0, y, std::max(0, x1 - x0), m.rail_height);
+}
+
+QRect ParamSlider::thumb_rect() const
+{
+  const Metrics &m = theme().metrics;
+  const QRect    rail = rail_rect();
+  const int      travel = std::max(0, rail.width() - m.thumb_width);
+  const int      x = rail.x() + int(std::round(norm_ * travel));
+  const int      y = (height() - m.thumb_height) / 2;
+  return QRect(x, y, m.thumb_width, m.thumb_height);
+}
+
+// --- value mapping
+
+qreal ParamSlider::to_norm(float value) const
+{
+  if (max_ <= min_) return 0.0;
+
+  if (log_scale_)
+  {
+    const qreal lo = std::log(qreal(min_));
+    const qreal hi = std::log(qreal(max_));
+    const qreal v = std::log(std::max(qreal(value), kLogFloor));
+    return std::clamp((v - lo) / (hi - lo), 0.0, 1.0);
+  }
+
+  return std::clamp(qreal(value - min_) / qreal(max_ - min_), 0.0, 1.0);
+}
+
+float ParamSlider::from_norm(qreal t) const
+{
+  t = std::clamp(t, 0.0, 1.0);
+
+  if (log_scale_)
+  {
+    const qreal lo = std::log(qreal(min_));
+    const qreal hi = std::log(qreal(max_));
+    return float(std::exp(lo + t * (hi - lo)));
+  }
+
+  return float(min_ + t * qreal(max_ - min_));
+}
+
+// --- painting
+
+void ParamSlider::paintEvent(QPaintEvent *)
+{
+  QPainter painter(this);
+  painter.setRenderHint(QPainter::Antialiasing, true);
+
+  const Theme   &t = theme();
+  const Metrics &m = t.metrics;
+  const bool     locked = is_locked();
+
+  // --- label. Text is the only thing state is allowed to change.
+  QFont label_font = ui_font(12, false, 1.0);
+  label_font.setCapitalization(QFont::AllUppercase);
+  painter.setFont(label_font);
+  painter.setPen(t.state_ink(is_modified(), locked));
+  const int label_w = label_width();
+  painter.drawText(QRect(0, 0, label_w, height()),
+                   Qt::AlignLeft | Qt::AlignVCenter,
+                   elide_label(QString::fromStdString(label_), label_font, label_w));
+
+  const QRect rail = rail_rect();
+  if (rail.width() <= 0) return;
+
+  // --- rail well
+  painter.setPen(QPen(t.rail_well_border, 1));
+  painter.setBrush(t.rail_well);
+  painter.drawRoundedRect(QRectF(rail).adjusted(0.5, 0.5, -0.5, -0.5),
+                          m.rail_radius,
+                          m.rail_radius);
+
+  // --- fill. Always the group accent; never a state colour.
+  const QRect thumb = thumb_rect();
+  const int   fill_w = thumb.center().x() - rail.x();
+  if (fill_w > 0)
+  {
+    QRect fill = rail.adjusted(0, 0, 0, 0);
+    fill.setWidth(std::min(fill_w, rail.width()));
+    painter.setPen(Qt::NoPen);
+    painter.setBrush(t.rail_fill(category_, locked));
+    painter.drawRoundedRect(QRectF(fill).adjusted(0.5, 0.5, -0.5, -0.5),
+                            m.rail_radius,
+                            m.rail_radius);
+  }
+
+  // --- thumb
+  painter.setOpacity(locked ? t.locked_thumb_alpha : 1.0);
+
+  QLinearGradient metal(thumb.topLeft(), thumb.bottomLeft());
+  metal.setColorAt(0.0, t.thumb_top);
+  metal.setColorAt(1.0, t.thumb_bottom);
+
+  painter.setPen(QPen(t.thumb_border, 1));
+  painter.setBrush(metal);
+  painter.drawRoundedRect(QRectF(thumb).adjusted(0.5, 0.5, -0.5, -0.5),
+                          m.radius,
+                          m.radius);
+
+  // grip notch, 2x8 centred
+  painter.setPen(Qt::NoPen);
+  painter.setBrush(t.thumb_grip);
+  painter.drawRect(QRect(thumb.center().x(), thumb.center().y() - 3, 2, 8));
+
+  painter.setOpacity(1.0);
+}
+
+void ParamSlider::resizeEvent(QResizeEvent *event)
+{
+  // Nothing here derives height from width, so a pure-height resize would be a
+  // wasted layout pass. Bail before touching child geometry.
+  if (event->oldSize().width() == event->size().width())
+  {
+    QWidget::resizeEvent(event);
+    return;
+  }
+
+  const Metrics &m = theme().metrics;
+  const int      fw = field_width();
+  field_->setGeometry(width() - fw,
+                      (height() - m.value_field_height) / 2,
+                      fw,
+                      m.value_field_height);
+
+  QWidget::resizeEvent(event);
+}
+
+// --- interaction
+
+void ParamSlider::mousePressEvent(QMouseEvent *event)
+{
+  if (is_locked() || event->button() != Qt::LeftButton)
+  {
+    event->ignore();
+    return;
+  }
+
+  const QRect rail = rail_rect();
+  if (!rail.adjusted(-4, -10, 4, 10).contains(event->pos()))
+  {
+    event->ignore();
+    return;
+  }
+
+  setFocus(Qt::MouseFocusReason);
+  dragging_ = true;
+  begin_edit();
+  set_from_position(event->pos().x());
+}
+
+void ParamSlider::mouseMoveEvent(QMouseEvent *event)
+{
+  if (!dragging_) return;
+  set_from_position(event->pos().x());
+}
+
+void ParamSlider::mouseReleaseEvent(QMouseEvent *event)
+{
+  if (!dragging_) return;
+
+  dragging_ = false;
+  set_from_position(event->pos().x());
+  end_edit();
+}
+
+void ParamSlider::mouseDoubleClickEvent(QMouseEvent *event)
+{
+  if (is_locked()) return;
+
+  const auto &provider = context().default_value;
+  if (!provider) return;
+
+  const std::any def = provider(key_);
+  if (!def.has_value()) return;
+
+  try
+  {
+    const float target = std::clamp(std::any_cast<float>(def), min_, max_);
+    dragging_ = false;
+    begin_edit();
+    glide_->to(to_norm(target)); // the reset glides like everything else
+  }
+  catch (const std::bad_any_cast &)
+  {
+    // A default of the wrong type is a host bug, not a reason to misbehave.
+  }
+
+  event->accept();
+}
+
+void ParamSlider::handle_wheel(QWheelEvent *event)
+{
+  const int steps = event->angleDelta().y() / 120;
+  if (steps == 0)
+  {
+    event->ignore();
+    return;
+  }
+
+  // One notch moves 1% of the rail, which stays sane under a log mapping.
+  begin_edit();
+  glide_->to(std::clamp(norm_ + steps * 0.01, 0.0, 1.0));
+  event->accept();
+}
+
+void ParamSlider::on_state_changed()
+{
+  restyle_field(field_ && field_->hasFocus());
+  update();
+}
+
+// --- helpers
+
+bool ParamSlider::eventFilter(QObject *watched, QEvent *event)
+{
+  if (watched == field_ &&
+      (event->type() == QEvent::FocusIn || event->type() == QEvent::FocusOut))
+  {
+    // hasFocus() is not yet settled while the event is being delivered, so the
+    // event type is the authority on which way the transition goes.
+    const bool editing = event->type() == QEvent::FocusIn;
+    if (!editing) refresh_field();
+    restyle_field(editing);
+  }
+
+  return Control<float>::eventFilter(watched, event);
+}
+
+void ParamSlider::set_from_position(int x)
+{
+  const Metrics &m = theme().metrics;
+  const QRect    rail = rail_rect();
+  const int      travel = std::max(1, rail.width() - m.thumb_width);
+
+  apply_norm(std::clamp(qreal(x - rail.x() - m.thumb_width / 2) / travel, 0.0, 1.0));
+}
+
+void ParamSlider::apply_norm(qreal t)
+{
+  // A drag tracks the cursor directly; gliding here would lag the pointer.
+  glide_->jump(t);
+  norm_ = t;
+  value_ = from_norm(t);
+  refresh_field();
+  update();
+  notify_value_changed();
+}
+
+QString ParamSlider::format_value(float value) const
+{
+  return QString::number(value, 'f', decimals_);
+}
+
+void ParamSlider::refresh_field()
+{
+  if (!field_ || field_->hasFocus()) return; // never overwrite mid-typing
+
+  const QSignalBlocker blocker(field_);
+  field_->setText(format_value(value_));
+}
+
+void ParamSlider::restyle_field(bool editing)
+{
+  if (!field_) return;
+
+  const Theme &t = theme();
+
+  const QColor bg = editing ? t.field_editing : t.field;
+  const QColor border = editing ? t.accent : t.field_border;
+
+  field_->setReadOnly(is_locked());
+  field_->setStyleSheet(QString("QLineEdit {"
+                                " background: %1;"
+                                " border: 1px solid %2;"
+                                " border-radius: %3px;"
+                                " color: %4;"
+                                " padding-right: 4px;"
+                                "}")
+                            .arg(bg.name())
+                            .arg(border.name())
+                            .arg(t.metrics.radius)
+                            .arg(t.state_ink(is_modified(), is_locked()).name()));
+}
+
+} // namespace meta::qt::industrial

--- a/MetaUI/qt/src/ui/control.cpp
+++ b/MetaUI/qt/src/ui/control.cpp
@@ -1,0 +1,81 @@
+/* Copyright (c) 2026 Otto Link. Distributed under the terms of the GNU General
+   Public License. The full license is in the file LICENSE, distributed with
+   this software. */
+#include "meta_qt/ui/control.hpp"
+
+#include <QFontMetrics>
+#include <QWheelEvent>
+
+namespace meta::qt
+{
+
+ControlBase::ControlBase(const RowContext &ctx, QWidget *parent)
+    : QWidget(parent), ctx_(ctx),
+      theme_(ctx.theme ? ctx.theme : &ThemeRegistry::instance().fallback())
+{
+  setFocusPolicy(Qt::StrongFocus);
+}
+
+void ControlBase::set_locked(bool locked)
+{
+  if (locked_ == locked) return;
+  locked_ = locked;
+  on_state_changed();
+}
+
+void ControlBase::set_modified(bool modified)
+{
+  if (modified_ == modified) return;
+  modified_ = modified;
+  on_state_changed();
+}
+
+void ControlBase::begin_edit()
+{
+  if (editing_) return;
+  editing_ = true;
+  Q_EMIT edit_started();
+}
+
+void ControlBase::end_edit()
+{
+  if (!editing_) return;
+  editing_ = false;
+  Q_EMIT edit_ended();
+}
+
+void ControlBase::notify_value_changed() { Q_EMIT value_changed(); }
+
+QString ControlBase::elide_label(const QString &text, const QFont &font, int width)
+{
+  const QFontMetrics metrics(font);
+  const QString      elided = metrics.elidedText(text, Qt::ElideRight, width);
+
+  if (elided != text && toolTip().isEmpty())
+  {
+    // The container sets ui.tooltip on the host row, not on the control, and it
+    // does so before the first paint -- so an empty parent tooltip here really
+    // does mean there is nothing to shadow.
+    QWidget *host = parentWidget();
+    if (!host || host->toolTip().isEmpty()) setToolTip(text);
+  }
+
+  return elided;
+}
+
+void ControlBase::handle_wheel(QWheelEvent *event) { event->ignore(); }
+
+void ControlBase::wheelEvent(QWheelEvent *event)
+{
+  // Unfocused controls must let the wheel through to the scroll area, or
+  // scrolling the panel edits whatever value happens to be under the cursor.
+  if (!hasFocus() || locked_)
+  {
+    event->ignore();
+    return;
+  }
+
+  handle_wheel(event);
+}
+
+} // namespace meta::qt

--- a/MetaUI/qt/src/ui/design_registry.cpp
+++ b/MetaUI/qt/src/ui/design_registry.cpp
@@ -1,0 +1,92 @@
+/* Copyright (c) 2026 Otto Link. Distributed under the terms of the GNU General
+   Public License. The full license is in the file LICENSE, distributed with
+   this software. */
+#include "meta_qt/ui/design_registry.hpp"
+
+#include "meta/logger.hpp"
+
+#include "meta_qt/widget_renderer.hpp"
+
+namespace meta::qt
+{
+
+DesignRegistry &DesignRegistry::instance()
+{
+  static DesignRegistry registry;
+  return registry;
+}
+
+void DesignRegistry::add(const std::string &design,
+                         std::type_index    type,
+                         const std::string &widget_type,
+                         RowFactory         factory)
+{
+  factories_[design][Key{type, widget_type}] = std::move(factory);
+}
+
+MetaWidget *DesignRegistry::render(AbstractAttribute *p_attr,
+                                   const std::string &design,
+                                   const RowContext  &ctx,
+                                   QWidget           *parent) const
+{
+  if (!p_attr) return nullptr;
+
+  auto design_it = factories_.find(design);
+  if (design_it == factories_.end()) return nullptr;
+
+  const auto &table = design_it->second;
+
+  // meta::common::widget_type() only has an Attribute<T> overload; on an
+  // AbstractAttribute the key has to be read directly.
+  const std::string widget_type = meta::common::try_get<std::string>(
+      *p_attr,
+      meta::keys::ui::widget_type,
+      "");
+
+  const std::type_index type{p_attr->type()};
+
+  if (auto it = table.find(Key{type, widget_type}); it != table.end())
+    return it->second(*p_attr, ctx, parent);
+
+  if (auto it = table.find(Key{type, kAnyWidgetType}); it != table.end())
+    return it->second(*p_attr, ctx, parent);
+
+  return nullptr;
+}
+
+bool DesignRegistry::has_design(const std::string &design) const
+{
+  return factories_.find(design) != factories_.end();
+}
+
+std::vector<std::string> DesignRegistry::designs() const
+{
+  std::vector<std::string> out;
+  out.reserve(factories_.size());
+  for (const auto &[name, _] : factories_)
+    out.push_back(name);
+  return out;
+}
+
+MetaWidget *render_row(AbstractAttribute *p_attr,
+                       const std::string &design,
+                       const RowContext  &ctx,
+                       QWidget           *parent)
+{
+  if (!p_attr)
+  {
+    Logger::log()->error("render_row: incoming p_attr is nullptr");
+    return nullptr;
+  }
+
+  if (MetaWidget *row = DesignRegistry::instance().render(p_attr, design, ctx, parent))
+    return row;
+
+  // Either nothing is registered for this (design, type, widget_type), or the
+  // registered control declined the attribute via can_render(). The stock
+  // renderer covers every type Meta supports, so an unported -- or unrenderable
+  // -- attribute degrades to a plain widget rather than leaving a gap.
+  return render(p_attr, parent);
+}
+
+} // namespace meta::qt

--- a/MetaUI/qt/src/ui/glide.cpp
+++ b/MetaUI/qt/src/ui/glide.cpp
@@ -1,0 +1,61 @@
+/* Copyright (c) 2026 Otto Link. Distributed under the terms of the GNU General
+   Public License. The full license is in the file LICENSE, distributed with
+   this software. */
+#include "meta_qt/ui/glide.hpp"
+
+#include <QEasingCurve>
+
+namespace meta::qt
+{
+
+Glide::Glide(int duration_ms, QObject *parent) : QObject(parent)
+{
+  animation_.setDuration(duration_ms);
+  animation_.setEasingCurve(QEasingCurve::OutCubic);
+
+  connect(&animation_,
+          &QVariantAnimation::valueChanged,
+          this,
+          [this](const QVariant &v)
+          {
+            current_ = v.toReal();
+            Q_EMIT tick(current_);
+          });
+
+  connect(&animation_,
+          &QVariantAnimation::finished,
+          this,
+          [this]() { Q_EMIT finished(current_); });
+}
+
+void Glide::to(qreal target)
+{
+  if (qFuzzyCompare(target, current_) && !running())
+  {
+    Q_EMIT finished(current_);
+    return;
+  }
+
+  // A running animation ignores a retargeted end value -- stop before
+  // retargeting or this call silently does nothing.
+  animation_.stop();
+  animation_.setStartValue(current_);
+  animation_.setEndValue(target);
+  animation_.start();
+}
+
+void Glide::jump(qreal value)
+{
+  animation_.stop();
+  current_ = value;
+  Q_EMIT tick(current_);
+}
+
+bool Glide::running() const
+{
+  return animation_.state() == QAbstractAnimation::Running;
+}
+
+void Glide::set_duration(int ms) { animation_.setDuration(ms); }
+
+} // namespace meta::qt

--- a/MetaUI/qt/src/ui/theme.cpp
+++ b/MetaUI/qt/src/ui/theme.cpp
@@ -1,0 +1,177 @@
+/* Copyright (c) 2026 Otto Link. Distributed under the terms of the GNU General
+   Public License. The full license is in the file LICENSE, distributed with
+   this software. */
+#include "meta_qt/ui/theme.hpp"
+
+#include <QFontDatabase>
+
+namespace meta::qt
+{
+
+// --- fonts
+
+QFont mono_font(int pixel_size)
+{
+  static const QString family = []() -> QString
+  {
+    // Probe rather than name a family: the obvious choices are each present on
+    // exactly one platform, and a missing family falls back to a proportional
+    // face without warning.
+    const QStringList candidates = {"Consolas",
+                                    "DejaVu Sans Mono",
+                                    "Menlo",
+                                    "Liberation Mono",
+                                    "Noto Sans Mono",
+                                    "Courier New"};
+
+    const QStringList available = QFontDatabase::families();
+    for (const QString &candidate : candidates)
+      if (available.contains(candidate))
+        return candidate;
+
+    return QFontDatabase::systemFont(QFontDatabase::FixedFont).family();
+  }();
+
+  QFont font(family);
+  font.setPixelSize(pixel_size);
+  font.setStyleHint(QFont::Monospace);
+  return font;
+}
+
+QFont ui_font(int pixel_size, bool bold, qreal letter_spacing)
+{
+  QFont font;
+  font.setPixelSize(pixel_size);
+  font.setBold(bold);
+  if (letter_spacing != 0.0)
+    font.setLetterSpacing(QFont::AbsoluteSpacing, letter_spacing);
+  return font;
+}
+
+// --- Theme
+
+QColor Theme::group_accent(const std::string &category) const
+{
+  auto it = group_accents.find(category);
+  return it == group_accents.end() ? accent : it->second;
+}
+
+QColor Theme::rail_fill(const std::string &category, bool locked) const
+{
+  QColor c = group_accent(category);
+  c.setAlphaF(locked ? locked_rail_fill_alpha : rail_fill_alpha);
+  return c;
+}
+
+QColor Theme::switch_track_on() const { return accent.darker(int(switch_track_on_darker * 100)); }
+
+QColor Theme::state_ink(bool modified, bool locked) const
+{
+  if (locked) return ink_locked;
+  return modified ? ink_modified : ink_secondary;
+}
+
+// --- ThemeRegistry
+
+namespace
+{
+
+/// The reference colourway, sampled from a render rather than copied from notes.
+Theme make_industrial_dark()
+{
+  Theme t;
+  t.name = "industrial-dark";
+  return t; // the struct defaults *are* industrial-dark
+}
+
+/** @brief A light colourway over the same geometry.
+ *
+ * Present so the theme layer has more than one occupant from day one -- a
+ * mechanism with a single implementation is untested by construction, and this
+ * is what proves the palette is genuinely swappable rather than nominally so.
+ */
+Theme make_industrial_light()
+{
+  Theme t;
+  t.name = "industrial-light";
+
+  t.page = QColor("#d9d9d9");
+  t.bar = QColor("#cfcfcf");
+  t.section_header = QColor("#c4c4c4");
+  t.section_header_hover = QColor("#bcbcbc");
+  t.section_header_press = QColor("#c9c9c9");
+  t.rail_well = QColor("#b8b8b8");
+  t.field = QColor("#ececec");
+  t.field_hover = QColor("#e2e2e2");
+  t.field_editing = QColor("#ffffff");
+  t.switch_track_off = QColor("#b8b8b8");
+
+  t.bevel_top = QColor("#e8e8e8");
+  t.bevel_bottom = QColor("#b0b0b0");
+  t.hairline = QColor("#a8a8a8");
+  t.rail_well_border = QColor("#9e9e9e");
+  t.field_border = QColor("#8a8a8a");
+  t.field_border_hover = QColor("#6e6e6e");
+
+  t.ink_primary = QColor("#1f1f1f");
+  t.ink_section_title = QColor("#2b2b2b");
+  t.ink_secondary = QColor("#5a5a5a");
+  t.ink_dim = QColor("#6e6e6e");
+  t.ink_locked = QColor("#a0a0a0");
+  t.ink_modified = QColor("#000000");
+  t.ink_icon = QColor("#3a3a3a");
+
+  t.thumb_top = QColor("#fbfbfb");
+  t.thumb_bottom = QColor("#d0d0d0");
+  t.thumb_border = QColor("#8a8a8a");
+  t.thumb_grip = QColor("#a8a8a8");
+  t.knob_on_top = QColor("#ffffff");
+  t.knob_on_bottom = QColor("#e0e0e0");
+  t.knob_off_top = QColor("#f0f0f0");
+  t.knob_off_bottom = QColor("#d4d4d4");
+
+  return t;
+}
+
+} // namespace
+
+ThemeRegistry::ThemeRegistry()
+{
+  add(make_industrial_dark());
+  add(make_industrial_light());
+  fallback_name_ = "industrial-dark";
+}
+
+ThemeRegistry &ThemeRegistry::instance()
+{
+  static ThemeRegistry registry;
+  return registry;
+}
+
+void ThemeRegistry::add(Theme theme)
+{
+  const std::string key = theme.name;
+  themes_[key] = std::move(theme);
+}
+
+const Theme &ThemeRegistry::get(const std::string &name) const
+{
+  auto it = themes_.find(name);
+  return it == themes_.end() ? fallback() : it->second;
+}
+
+const Theme &ThemeRegistry::fallback() const
+{
+  return themes_.at(fallback_name_);
+}
+
+std::vector<std::string> ThemeRegistry::names() const
+{
+  std::vector<std::string> out;
+  out.reserve(themes_.size());
+  for (const auto &[name, _] : themes_)
+    out.push_back(name);
+  return out;
+}
+
+} // namespace meta::qt


### PR DESCRIPTION
Adds a design layer under `meta_qt` so a host can supply an alternative look for attribute rows without forking the renderer.

Opening this early and deliberately small — the architecture plus two proof widgets — because the shape is much easier to discuss now than after a full widget set is built on top of it. Happy to change any of it.

## Why

A row is currently produced by three hardcoded cascades: an if-chain on `typeid`, a `WidgetRenderer<T>` specialisation, then an if-chain on the `widget_type` string.

`WidgetRenderer<float>::render()` also does five jobs at once — read metadata, pick a control, construct it, wire control→attribute, wire attribute→control — and the last two are copy-pasted into each branch of that function. So a second visual variant means duplicating the model wiring, and the wiring is where the subtle bugs are: a sync arriving mid-drag, feedback loops on write-back, subscription lifetime.

## What

Four layers, all additive:

| | |
|---|---|
| `ui/theme.hpp` | `Theme` as a value type + registry, not process-wide globals. Derived colours are formulas, so an accent change propagates. Two colourways ship, so the mechanism has more than one occupant. |
| `ui/control.hpp` | `ControlBase` / `Control<T>`. Wheel ignored unless focused (`wheelEvent` is `final`; override `handle_wheel`); the editing flag is only settable via `begin_edit`/`end_edit` alongside its signal. |
| `ui/binding.hpp` | `bind<T>()` — once per *type*, never per design. Owns the sync-vs-edit guard, signal blocking, subscription lifetime. |
| `ui/design_registry.hpp` | `(design, type, widget_type)` → factory. Resolves exact → wildcard → stock fallback. |

`designs/industrial/` supplies a float slider and a bool toggle as proof the seam is real, not a single implementation wearing an interface.

Controls provide `static bool can_render(const Attribute<T>&)`, so an attribute a design can't honour — a rail with no `min`/`max` — declines and falls back to stock instead of rendering a `[0, 0]` range.

## Compatibility

`ContainerRenderOptions` gains one field, `row_renderer`, threaded to the three row-building sites. **Left empty it calls `qt::render()` exactly as before** — no behaviour change unless a host opts in. An unregistered design name resolves nothing and every row falls back, so a partially covered design still yields a complete panel.

## Status

Built and exercised in Hesiod on Qt 6.10.3 / MSVC 2022. The two controls cover ~72% of the rows in a Hesiod node panel; everything else renders stock. Drag, glide-on-reset, typed commit, wheel-focus behaviour and toggle all verified by hand.

Not included yet, deliberately: section chrome, `SliderInt`, `EnumComboBox`. Those are the next slice once the shape here is agreed.