### PR TITLE
feat: share and manage ColorGradient presets

### DIFF
--- a/Meta/include/meta.hpp
+++ b/Meta/include/meta.hpp
@@ -33,6 +33,8 @@
 
 #ifdef META_ENABLE_COLOR_GRADIENT_TYPES
 #include "meta/ext/color_gradient/color_gradient.hpp"
+#include "meta/ext/color_gradient/gradient_library.hpp"
+#include "meta/ext/color_gradient/gradient_metrics.hpp"
 #endif
 
 #ifdef META_ENABLE_ARRAY_TYPES

--- a/Meta/include/meta/ext/color_gradient/color_gradient.hpp
+++ b/Meta/include/meta/ext/color_gradient/color_gradient.hpp
@@ -8,35 +8,35 @@
 
 #include <nlohmann/json.hpp>
 
-namespace meta
-{
+namespace meta {
 
 /// A color stop in a gradient.
-struct Stop
-{
+struct Stop {
   /// Position in the range [0, 1].
   float position;
 
   /// RGBA color.
   std::array<float, 4> color;
+
+  bool operator==(const Stop &) const = default;
 };
 
 /// A named color gradient preset.
-struct Preset
-{
+struct Preset {
   /// Preset name.
   std::string name;
 
   /// Gradient stops.
   std::vector<Stop> stops;
+
+  bool operator==(const Preset &) const = default;
 };
 
 /// Editable color gradient. Presets are deliberately NOT part of this value
 /// type: they are host configuration, carried in attribute metadata as a
 /// GradientPresets entry (keys::ui::presets), so that deserializing a value
 /// cannot clobber the preset library installed at setup time.
-class ColorGradient
-{
+class ColorGradient {
 public:
   /// Constructs a default black-to-white gradient.
   ColorGradient() = default;
@@ -72,8 +72,7 @@ private:
 /// Preset library for a gradient attribute, installed by the host into
 /// attribute metadata under keys::ui::presets. Runtime configuration, not
 /// document state: never serialized (mirrors meta::DataProvider).
-struct GradientPresets
-{
+struct GradientPresets {
   /// Available presets.
   std::vector<Preset> presets;
 };

--- a/Meta/include/meta/ext/color_gradient/gradient_library.hpp
+++ b/Meta/include/meta/ext/color_gradient/gradient_library.hpp
@@ -1,0 +1,186 @@
+/* Copyright (c) 2026 Otto Link. Distributed under the terms of the GNU General
+   Public License. The full license is in the file LICENSE, distributed with
+   this software. */
+#pragma once
+#include <cstddef>
+#include <filesystem>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include <nlohmann/json.hpp>
+
+#include "meta/core/event.hpp"
+#include "meta/ext/color_gradient/color_gradient.hpp"
+
+namespace meta {
+
+/// Ordering applied to preset grids. Favourites are always pinned first.
+enum class GradientSort {
+  Default,   ///< host order, then library insertion order
+  Name,      ///< case-insensitive name
+  Luminance, ///< dark to light (gradient_luminance)
+  Hue        ///< around the colour wheel, achromatic last (gradient_hue)
+};
+
+/// Persisted identifier of a sort key ("default", "name", "luminance", "hue").
+std::string_view to_string(GradientSort sort);
+
+/// Inverse of to_string(GradientSort); std::nullopt for unknown identifiers.
+std::optional<GradientSort> gradient_sort_from_string(std::string_view text);
+
+/// Outcome of GradientLibrary::import_file().
+struct GradientImportReport {
+  std::size_t added = 0;   ///< stored under their own name
+  std::size_t renamed = 0; ///< stored under a suffixed name (name clash)
+  std::size_t skipped = 0; ///< identical to an existing preset
+  bool ok = false;         ///< file could be read and held gradients
+};
+
+/**
+ * @brief Gradient file document ("meta.gradients", version 1) for a list of
+ * presets:
+ * @code
+ * {"format": "meta.gradients", "version": 1,
+ *  "gradients": [{"name": "...", "stops": [{"position": t, "color":
+ * [r,g,b,a]}]}]}
+ * @endcode
+ */
+nlohmann::json gradient_file_json(const std::vector<Preset> &presets);
+
+/**
+ * @brief Tolerant reader for gradient files.
+ *
+ * Accepts the document produced by gradient_file_json(), a bare array of
+ * gradients, or a single gradient object. A gradient's stops may live under
+ * "stops" or "value" (the ColorGradient::json_to() shape); a missing name
+ * falls back to `fallback_name` (numbered when the file holds several);
+ * colours with any component above 1 are read as 0-255; RGB colours get
+ * alpha 1; entries with fewer than two valid stops are dropped.
+ *
+ * @return The parsed presets, or std::nullopt when nothing usable was found.
+ */
+std::optional<std::vector<Preset>>
+parse_gradient_file(const nlohmann::json &json,
+                    std::string_view fallback_name = "Gradient");
+
+/**
+ * @brief The user's gradient presets, shared by every gradient widget in the
+ * process and persisted across projects.
+ *
+ * Holds user presets (insertion ordered), favourite names (which may also
+ * refer to host presets that are not in the library) and the preferred sort
+ * key. Every effective mutation autosaves to path() (when set) and notifies
+ * `changed`. Hosts normally use instance(); the class stays instantiable for
+ * tests and for hosts that want several libraries.
+ *
+ * The Qt GradientPicker assigns a default per-user path on first use when
+ * none is set; call set_path() + load() beforehand to choose another.
+ */
+class GradientLibrary {
+public:
+  /// Fired after every effective mutation and after a successful load.
+  Event<> changed;
+
+  GradientLibrary() = default;
+
+  /// Process-wide default library.
+  static GradientLibrary &instance();
+
+  // --- storage
+
+  /// Sets the file used by load()/save() and by autosave. Does not load.
+  void set_path(std::filesystem::path path);
+
+  /// File used for persistence; empty when the library is in-memory only.
+  const std::filesystem::path &path() const;
+
+  /// Whether mutations save automatically (default true).
+  void set_autosave(bool on);
+  bool autosave() const;
+
+  /**
+   * @brief Replaces the content with the document at path().
+   * @return false when no path is set, the file is missing or invalid; the
+   * current content is left untouched in every failure case.
+   */
+  bool load();
+
+  /// Writes json_to() to path(), creating parent directories.
+  bool save() const;
+
+  // --- user presets
+
+  const std::vector<Preset> &presets() const;
+  bool has(std::string_view name) const;
+  const Preset *find(std::string_view name) const;
+
+  /**
+   * @brief Stores a preset. The name is trimmed ("Gradient" when empty) and
+   * made unique with unique_name(); stops are sorted by position.
+   * @return The name the preset was stored under.
+   */
+  std::string add(Preset preset);
+
+  /// Replaces the stops of an existing preset (sorted by position).
+  bool update(std::string_view name, std::vector<Stop> stops);
+
+  /// Renames a preset, carrying its favourite flag along. Fails when `from`
+  /// is unknown, `to` is blank, or `to` already exists (unless equal).
+  bool rename(std::string_view from, std::string_view to);
+
+  /// Removes a preset and its favourite flag.
+  bool remove(std::string_view name);
+
+  /// Removes every preset and favourite.
+  void clear();
+
+  /// `base` if free, otherwise "base (2)", "base (3)", ...; names in
+  /// `reserved` (e.g. host presets) count as taken.
+  std::string unique_name(std::string_view base,
+                          const std::vector<std::string> &reserved = {}) const;
+
+  // --- favourites
+
+  bool is_favorite(std::string_view name) const;
+  void set_favorite(std::string_view name, bool on);
+  const std::vector<std::string> &favorites() const;
+
+  // --- sort preference
+
+  GradientSort sort() const;
+  void set_sort(GradientSort sort);
+
+  // --- serialization
+
+  /// Library document: gradient_file_json() plus "favorites" and "sort".
+  nlohmann::json json_to() const;
+
+  /// Replaces the content from a library document; false (state untouched)
+  /// unless `json` is an object with a "gradients" array.
+  bool json_from(const nlohmann::json &json);
+
+  /**
+   * @brief Merges the gradients of a file into the library.
+   *
+   * Identical duplicates (same name and stops) are skipped; name clashes are
+   * stored under unique_name(); everything else is added as is.
+   */
+  GradientImportReport import_file(const std::filesystem::path &path);
+
+  /// Writes `presets` as a gradient file (no favourites, no sort).
+  bool export_file(const std::filesystem::path &path,
+                   const std::vector<Preset> &presets) const;
+
+private:
+  void on_modified();
+
+  std::vector<Preset> presets_;
+  std::vector<std::string> favorites_;
+  GradientSort sort_ = GradientSort::Default;
+  std::filesystem::path path_;
+  bool autosave_ = true;
+};
+
+} // namespace meta

--- a/Meta/include/meta/ext/color_gradient/gradient_metrics.hpp
+++ b/Meta/include/meta/ext/color_gradient/gradient_metrics.hpp
@@ -1,0 +1,39 @@
+/* Copyright (c) 2026 Otto Link. Distributed under the terms of the GNU General
+   Public License. The full license is in the file LICENSE, distributed with
+   this software. */
+#pragma once
+#include <array>
+#include <vector>
+
+#include "meta/ext/color_gradient/color_gradient.hpp"
+
+namespace meta {
+
+/**
+ * @brief Colour of a gradient at position `t`.
+ *
+ * Linear interpolation between the two stops bracketing `t` (clamped to
+ * [0, 1]); positions outside the stop range hold the end colours. Stops need
+ * not be sorted. An empty gradient samples as opaque black.
+ */
+std::array<float, 4> sample_gradient(const std::vector<Stop> &stops, float t);
+
+/**
+ * @brief Mean Rec.709 luma of the gradient in [0, 1].
+ *
+ * Averages `samples` evenly spaced samples of `0.2126 R + 0.7152 G + 0.0722 B`
+ * on the stored (sRGB-encoded) components; alpha is ignored. Used for the
+ * "Luminance" sort of preset grids.
+ */
+float gradient_luminance(const std::vector<Stop> &stops, int samples = 32);
+
+/**
+ * @brief Dominant hue of the gradient in degrees [0, 360).
+ *
+ * Saturation-weighted circular mean of the HSV hue over `samples` evenly
+ * spaced samples. Returns -1 when the gradient is achromatic (total
+ * saturation weight below 1e-4), so hue-sorted lists can push greys last.
+ */
+float gradient_hue(const std::vector<Stop> &stops, int samples = 32);
+
+} // namespace meta

--- a/Meta/src/ext/color_gradient/gradient_library.cpp
+++ b/Meta/src/ext/color_gradient/gradient_library.cpp
@@ -1,0 +1,517 @@
+/* Copyright (c) 2026 Otto Link. Distributed under the terms of the GNU General
+   Public License. The full license is in the file LICENSE, distributed with
+   this software. */
+#include <algorithm>
+#include <cctype>
+#include <fstream>
+
+#include "meta/ext/color_gradient/gradient_library.hpp"
+#include "meta/logger.hpp"
+
+namespace meta {
+
+namespace {
+
+constexpr char kFileFormat[] = "meta.gradients";
+constexpr int kFileVersion = 1;
+constexpr char kDefaultName[] = "Gradient";
+
+std::string trim(std::string_view text) {
+  const auto not_space = [](unsigned char c) { return !std::isspace(c); };
+  const auto begin = std::find_if(text.begin(), text.end(), not_space);
+  const auto end = std::find_if(text.rbegin(), text.rend(), not_space).base();
+  return begin < end ? std::string(begin, end) : std::string();
+}
+
+void sort_stops(std::vector<Stop> &stops) {
+  std::stable_sort(
+      stops.begin(), stops.end(),
+      [](const Stop &a, const Stop &b) { return a.position < b.position; });
+}
+
+bool parse_color(const nlohmann::json &json, std::array<float, 4> &out) {
+  if (!json.is_array() || json.size() < 3)
+    return false;
+
+  const std::size_t n = std::min<std::size_t>(4, json.size());
+  std::array<float, 4> color = {0.f, 0.f, 0.f, 1.f};
+  bool over_one = false;
+
+  for (std::size_t k = 0; k < n; ++k) {
+    if (!json[k].is_number())
+      return false;
+    color[k] = json[k].get<float>();
+    if (color[k] > 1.f)
+      over_one = true;
+  }
+
+  // 0-255 encoded colours (e.g. Hesiod's data/color_gradient.json)
+  if (over_one)
+    for (std::size_t k = 0; k < n; ++k)
+      color[k] /= 255.f;
+
+  for (float &v : color)
+    v = std::clamp(v, 0.f, 1.f);
+
+  out = color;
+  return true;
+}
+
+std::optional<Preset> parse_preset(const nlohmann::json &json,
+                                   std::string_view fallback_name) {
+  if (!json.is_object())
+    return std::nullopt;
+
+  const nlohmann::json *stops_json = nullptr;
+  if (json.contains("stops") && json["stops"].is_array())
+    stops_json = &json["stops"];
+  else if (json.contains("value") && json["value"].is_array())
+    stops_json = &json["value"];
+
+  if (!stops_json)
+    return std::nullopt;
+
+  Preset preset;
+  if (json.contains("name") && json["name"].is_string())
+    preset.name = trim(json["name"].get<std::string>());
+  if (preset.name.empty())
+    preset.name = std::string(fallback_name);
+
+  for (const auto &s : *stops_json) {
+    if (!s.is_object() || !s.contains("position") ||
+        !s["position"].is_number() || !s.contains("color"))
+      continue;
+
+    std::array<float, 4> color;
+    if (!parse_color(s["color"], color))
+      continue;
+
+    preset.stops.push_back(
+        {std::clamp(s["position"].get<float>(), 0.f, 1.f), color});
+  }
+
+  if (preset.stops.size() < 2)
+    return std::nullopt;
+
+  sort_stops(preset.stops);
+  return preset;
+}
+
+std::vector<Preset> parse_preset_list(const nlohmann::json &array,
+                                      std::string_view fallback_name) {
+  std::vector<Preset> out;
+  std::size_t index = 0;
+
+  for (const auto &g : array) {
+    ++index;
+    const std::string fallback =
+        array.size() > 1
+            ? std::string(fallback_name) + " " + std::to_string(index)
+            : std::string(fallback_name);
+
+    if (auto preset = parse_preset(g, fallback))
+      out.push_back(std::move(*preset));
+    else
+      Logger::log()->warn(
+          "parse_gradient_file: skipping invalid gradient entry #{}", index);
+  }
+
+  return out;
+}
+
+bool read_json_file(const std::filesystem::path &path, nlohmann::json &out) {
+  std::ifstream file(path);
+  if (!file) {
+    Logger::log()->error("GradientLibrary: cannot open '{}'", path.string());
+    return false;
+  }
+
+  try {
+    file >> out;
+  } catch (const std::exception &e) {
+    Logger::log()->error("GradientLibrary: cannot parse '{}': {}",
+                         path.string(), e.what());
+    return false;
+  }
+
+  return true;
+}
+
+bool write_json_file(const std::filesystem::path &path,
+                     const nlohmann::json &json) {
+  std::error_code ec;
+  if (path.has_parent_path())
+    std::filesystem::create_directories(path.parent_path(), ec);
+
+  std::ofstream file(path);
+  if (!file) {
+    Logger::log()->error("GradientLibrary: cannot write '{}'", path.string());
+    return false;
+  }
+
+  file << json.dump(2) << '\n';
+  return static_cast<bool>(file);
+}
+
+} // namespace
+
+// ---------------------------------------------------------------------------
+// Free functions
+// ---------------------------------------------------------------------------
+
+std::string_view to_string(GradientSort sort) {
+  switch (sort) {
+  case GradientSort::Name:
+    return "name";
+  case GradientSort::Luminance:
+    return "luminance";
+  case GradientSort::Hue:
+    return "hue";
+  case GradientSort::Default:
+  default:
+    return "default";
+  }
+}
+
+std::optional<GradientSort> gradient_sort_from_string(std::string_view text) {
+  for (GradientSort s : {GradientSort::Default, GradientSort::Name,
+                         GradientSort::Luminance, GradientSort::Hue})
+    if (text == to_string(s))
+      return s;
+  return std::nullopt;
+}
+
+nlohmann::json gradient_file_json(const std::vector<Preset> &presets) {
+  nlohmann::json json;
+  json["format"] = kFileFormat;
+  json["version"] = kFileVersion;
+  json["gradients"] = nlohmann::json::array();
+
+  for (const auto &preset : presets) {
+    nlohmann::json g;
+    g["name"] = preset.name;
+    g["stops"] = nlohmann::json::array();
+    for (const auto &s : preset.stops)
+      g["stops"].push_back({{"position", s.position}, {"color", s.color}});
+    json["gradients"].push_back(std::move(g));
+  }
+
+  return json;
+}
+
+std::optional<std::vector<Preset>>
+parse_gradient_file(const nlohmann::json &json,
+                    std::string_view fallback_name) {
+  std::vector<Preset> out;
+
+  if (json.is_array())
+    out = parse_preset_list(json, fallback_name);
+  else if (json.is_object() && json.contains("gradients") &&
+           json["gradients"].is_array())
+    out = parse_preset_list(json["gradients"], fallback_name);
+  else if (auto preset = parse_preset(json, fallback_name))
+    out.push_back(std::move(*preset));
+
+  if (out.empty())
+    return std::nullopt;
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// GradientLibrary
+// ---------------------------------------------------------------------------
+
+GradientLibrary &GradientLibrary::instance() {
+  static GradientLibrary library;
+  return library;
+}
+
+void GradientLibrary::set_path(std::filesystem::path path) {
+  path_ = std::move(path);
+}
+
+const std::filesystem::path &GradientLibrary::path() const { return path_; }
+
+void GradientLibrary::set_autosave(bool on) { autosave_ = on; }
+
+bool GradientLibrary::autosave() const { return autosave_; }
+
+bool GradientLibrary::load() {
+  if (path_.empty()) {
+    Logger::log()->warn("GradientLibrary::load: no path set");
+    return false;
+  }
+
+  std::error_code ec;
+  if (!std::filesystem::exists(path_, ec)) {
+    Logger::log()->trace("GradientLibrary::load: no file at '{}'",
+                         path_.string());
+    return false;
+  }
+
+  nlohmann::json json;
+  if (!read_json_file(path_, json))
+    return false;
+
+  if (!json_from(json)) {
+    Logger::log()->warn("GradientLibrary::load: '{}' is not a gradient library",
+                        path_.string());
+    return false;
+  }
+
+  Logger::log()->trace("GradientLibrary::load: {} presets from '{}'",
+                       presets_.size(), path_.string());
+  return true;
+}
+
+bool GradientLibrary::save() const {
+  if (path_.empty()) {
+    Logger::log()->trace("GradientLibrary::save: no path set, skipping");
+    return false;
+  }
+  return write_json_file(path_, json_to());
+}
+
+const std::vector<Preset> &GradientLibrary::presets() const { return presets_; }
+
+bool GradientLibrary::has(std::string_view name) const {
+  return find(name) != nullptr;
+}
+
+const Preset *GradientLibrary::find(std::string_view name) const {
+  const auto it =
+      std::find_if(presets_.begin(), presets_.end(),
+                   [name](const Preset &p) { return p.name == name; });
+  return it == presets_.end() ? nullptr : &*it;
+}
+
+std::string GradientLibrary::add(Preset preset) {
+  preset.name = unique_name(preset.name);
+  sort_stops(preset.stops);
+
+  Logger::log()->trace("GradientLibrary::add: '{}'", preset.name);
+
+  presets_.push_back(std::move(preset));
+  const std::string name = presets_.back().name;
+  on_modified();
+  return name;
+}
+
+bool GradientLibrary::update(std::string_view name, std::vector<Stop> stops) {
+  const auto it =
+      std::find_if(presets_.begin(), presets_.end(),
+                   [name](const Preset &p) { return p.name == name; });
+  if (it == presets_.end())
+    return false;
+
+  sort_stops(stops);
+  it->stops = std::move(stops);
+
+  Logger::log()->trace("GradientLibrary::update: '{}'", it->name);
+  on_modified();
+  return true;
+}
+
+bool GradientLibrary::rename(std::string_view from, std::string_view to) {
+  const std::string new_name = trim(to);
+
+  const auto it =
+      std::find_if(presets_.begin(), presets_.end(),
+                   [from](const Preset &p) { return p.name == from; });
+  if (it == presets_.end() || new_name.empty())
+    return false;
+  if (new_name == it->name)
+    return true;
+  if (has(new_name))
+    return false;
+
+  const std::string old_name = it->name;
+  it->name = new_name;
+
+  for (auto &favorite : favorites_)
+    if (favorite == old_name)
+      favorite = new_name;
+
+  Logger::log()->trace("GradientLibrary::rename: '{}' -> '{}'", old_name,
+                       new_name);
+  on_modified();
+  return true;
+}
+
+bool GradientLibrary::remove(std::string_view name) {
+  const auto it =
+      std::find_if(presets_.begin(), presets_.end(),
+                   [name](const Preset &p) { return p.name == name; });
+  if (it == presets_.end())
+    return false;
+
+  const std::string removed = it->name; // `name` may alias it->name
+  presets_.erase(it);
+  favorites_.erase(std::remove(favorites_.begin(), favorites_.end(), removed),
+                   favorites_.end());
+
+  Logger::log()->trace("GradientLibrary::remove: '{}'", removed);
+  on_modified();
+  return true;
+}
+
+void GradientLibrary::clear() {
+  Logger::log()->trace("GradientLibrary::clear ({} presets)", presets_.size());
+  presets_.clear();
+  favorites_.clear();
+  on_modified();
+}
+
+std::string
+GradientLibrary::unique_name(std::string_view base,
+                             const std::vector<std::string> &reserved) const {
+  std::string name = trim(base);
+  if (name.empty())
+    name = kDefaultName;
+
+  const auto taken = [&](const std::string &candidate) {
+    return has(candidate) || std::find(reserved.begin(), reserved.end(),
+                                       candidate) != reserved.end();
+  };
+
+  if (!taken(name))
+    return name;
+
+  for (int i = 2;; ++i) {
+    const std::string candidate = name + " (" + std::to_string(i) + ")";
+    if (!taken(candidate))
+      return candidate;
+  }
+}
+
+bool GradientLibrary::is_favorite(std::string_view name) const {
+  return std::find(favorites_.begin(), favorites_.end(), name) !=
+         favorites_.end();
+}
+
+void GradientLibrary::set_favorite(std::string_view name, bool on) {
+  const auto it = std::find(favorites_.begin(), favorites_.end(), name);
+  const bool present = it != favorites_.end();
+  if (on == present)
+    return;
+
+  if (on)
+    favorites_.emplace_back(name);
+  else
+    favorites_.erase(it);
+
+  Logger::log()->trace("GradientLibrary::set_favorite: '{}' -> {}", name, on);
+  on_modified();
+}
+
+const std::vector<std::string> &GradientLibrary::favorites() const {
+  return favorites_;
+}
+
+GradientSort GradientLibrary::sort() const { return sort_; }
+
+void GradientLibrary::set_sort(GradientSort sort) {
+  if (sort == sort_)
+    return;
+  sort_ = sort;
+  on_modified();
+}
+
+nlohmann::json GradientLibrary::json_to() const {
+  nlohmann::json json = gradient_file_json(presets_);
+  json["favorites"] = favorites_;
+  json["sort"] = std::string(to_string(sort_));
+  return json;
+}
+
+bool GradientLibrary::json_from(const nlohmann::json &json) {
+  if (!json.is_object() || !json.contains("gradients") ||
+      !json["gradients"].is_array())
+    return false;
+
+  std::vector<Preset> presets =
+      parse_preset_list(json["gradients"], kDefaultName);
+
+  std::vector<std::string> favorites;
+  if (json.contains("favorites") && json["favorites"].is_array())
+    for (const auto &f : json["favorites"]) {
+      if (!f.is_string())
+        continue;
+      const std::string name = f.get<std::string>();
+      if (std::find(favorites.begin(), favorites.end(), name) ==
+          favorites.end())
+        favorites.push_back(name);
+    }
+
+  GradientSort sort = GradientSort::Default;
+  if (json.contains("sort") && json["sort"].is_string())
+    if (const auto s =
+            gradient_sort_from_string(json["sort"].get<std::string>()))
+      sort = *s;
+
+  presets_.clear();
+  for (auto &preset : presets) {
+    preset.name = unique_name(preset.name);
+    presets_.push_back(std::move(preset));
+  }
+  favorites_ = std::move(favorites);
+  sort_ = sort;
+
+  changed.notify();
+  return true;
+}
+
+GradientImportReport
+GradientLibrary::import_file(const std::filesystem::path &path) {
+  GradientImportReport report;
+
+  nlohmann::json json;
+  if (!read_json_file(path, json))
+    return report;
+
+  const auto parsed = parse_gradient_file(json, path.stem().string());
+  if (!parsed) {
+    Logger::log()->warn("GradientLibrary::import_file: no gradients in '{}'",
+                        path.string());
+    return report;
+  }
+
+  for (Preset preset : *parsed) {
+    if (const Preset *existing = find(preset.name)) {
+      if (existing->stops == preset.stops) {
+        ++report.skipped;
+        continue;
+      }
+      preset.name = unique_name(preset.name);
+      ++report.renamed;
+    } else {
+      ++report.added;
+    }
+    presets_.push_back(std::move(preset));
+  }
+
+  report.ok = true;
+
+  Logger::log()->trace(
+      "GradientLibrary::import_file: '{}': {} added, {} renamed, {} skipped",
+      path.string(), report.added, report.renamed, report.skipped);
+
+  if (report.added + report.renamed > 0)
+    on_modified();
+  return report;
+}
+
+bool GradientLibrary::export_file(const std::filesystem::path &path,
+                                  const std::vector<Preset> &presets) const {
+  Logger::log()->trace("GradientLibrary::export_file: {} presets to '{}'",
+                       presets.size(), path.string());
+  return write_json_file(path, gradient_file_json(presets));
+}
+
+void GradientLibrary::on_modified() {
+  if (autosave_ && !path_.empty())
+    save();
+  changed.notify();
+}
+
+} // namespace meta

--- a/Meta/src/ext/color_gradient/gradient_metrics.cpp
+++ b/Meta/src/ext/color_gradient/gradient_metrics.cpp
@@ -1,0 +1,138 @@
+/* Copyright (c) 2026 Otto Link. Distributed under the terms of the GNU General
+   Public License. The full license is in the file LICENSE, distributed with
+   this software. */
+#include <algorithm>
+#include <cmath>
+#include <numbers>
+
+#include "meta/ext/color_gradient/gradient_metrics.hpp"
+
+namespace meta {
+
+namespace {
+
+std::vector<Stop> sorted_stops(const std::vector<Stop> &stops) {
+  std::vector<Stop> sorted = stops;
+  std::stable_sort(
+      sorted.begin(), sorted.end(),
+      [](const Stop &a, const Stop &b) { return a.position < b.position; });
+  return sorted;
+}
+
+// Expects sorted, non-empty stops.
+std::array<float, 4> sample_sorted(const std::vector<Stop> &sorted, float t) {
+  t = std::clamp(t, 0.f, 1.f);
+
+  if (t <= sorted.front().position)
+    return sorted.front().color;
+  if (t >= sorted.back().position)
+    return sorted.back().color;
+
+  for (std::size_t i = 1; i < sorted.size(); ++i) {
+    if (t > sorted[i].position)
+      continue;
+
+    const Stop &a = sorted[i - 1];
+    const Stop &b = sorted[i];
+    const float span = b.position - a.position;
+    const float u = span > 0.f ? (t - a.position) / span : 1.f;
+
+    std::array<float, 4> out{};
+    for (std::size_t k = 0; k < 4; ++k)
+      out[k] = a.color[k] + (b.color[k] - a.color[k]) * u;
+    return out;
+  }
+
+  return sorted.back().color;
+}
+
+float sample_position(int i, int samples) {
+  return samples == 1 ? 0.5f : float(i) / float(samples - 1);
+}
+
+// HSV hue in degrees [0, 360) and saturation in [0, 1].
+void hue_saturation(const std::array<float, 4> &c, float &hue, float &sat) {
+  const float r = std::clamp(c[0], 0.f, 1.f);
+  const float g = std::clamp(c[1], 0.f, 1.f);
+  const float b = std::clamp(c[2], 0.f, 1.f);
+  const float mx = std::max({r, g, b});
+  const float mn = std::min({r, g, b});
+  const float d = mx - mn;
+
+  hue = 0.f;
+  sat = mx > 0.f ? d / mx : 0.f;
+  if (d <= 1e-6f)
+    return;
+
+  float h;
+  if (mx == r)
+    h = std::fmod((g - b) / d, 6.f);
+  else if (mx == g)
+    h = (b - r) / d + 2.f;
+  else
+    h = (r - g) / d + 4.f;
+
+  h *= 60.f;
+  if (h < 0.f)
+    h += 360.f;
+  hue = h;
+}
+
+} // namespace
+
+std::array<float, 4> sample_gradient(const std::vector<Stop> &stops, float t) {
+  if (stops.empty())
+    return {0.f, 0.f, 0.f, 1.f};
+  return sample_sorted(sorted_stops(stops), t);
+}
+
+float gradient_luminance(const std::vector<Stop> &stops, int samples) {
+  if (stops.empty() || samples <= 0)
+    return 0.f;
+
+  const std::vector<Stop> sorted = sorted_stops(stops);
+  float sum = 0.f;
+
+  for (int i = 0; i < samples; ++i) {
+    const auto c = sample_sorted(sorted, sample_position(i, samples));
+    sum += 0.2126f * std::clamp(c[0], 0.f, 1.f) +
+           0.7152f * std::clamp(c[1], 0.f, 1.f) +
+           0.0722f * std::clamp(c[2], 0.f, 1.f);
+  }
+
+  return sum / float(samples);
+}
+
+float gradient_hue(const std::vector<Stop> &stops, int samples) {
+  if (stops.empty() || samples <= 0)
+    return -1.f;
+
+  const std::vector<Stop> sorted = sorted_stops(stops);
+  double sx = 0.0;
+  double sy = 0.0;
+  double weight = 0.0;
+
+  for (int i = 0; i < samples; ++i) {
+    float hue = 0.f;
+    float sat = 0.f;
+    hue_saturation(sample_sorted(sorted, sample_position(i, samples)), hue,
+                   sat);
+
+    const double rad = double(hue) * std::numbers::pi / 180.0;
+    sx += sat * std::cos(rad);
+    sy += sat * std::sin(rad);
+    weight += sat;
+  }
+
+  if (weight < 1e-4)
+    return -1.f;
+
+  double deg = std::atan2(sy, sx) * 180.0 / std::numbers::pi;
+  if (deg < 0.0)
+    deg += 360.0;
+  if (deg >= 360.0)
+    deg -= 360.0;
+  return float(deg);
+}
+
+} // namespace meta

--- a/MetaUI/qt/include/meta_qt/widgets/gradient_picker.hpp
+++ b/MetaUI/qt/include/meta_qt/widgets/gradient_picker.hpp
@@ -8,12 +8,15 @@
 
 #include <QWidget>
 
+#include "meta/core/event.hpp"
 #include "meta/ext/color_gradient/color_gradient.hpp"
 
+class QComboBox;
+class QPixmap;
 class QScrollArea;
+class QToolButton;
 
-namespace meta::qt
-{
+namespace meta::qt {
 
 class PresetGridWidget;
 
@@ -23,8 +26,7 @@ class PresetGridWidget;
 // Custom-painted gradient bar with interactive stop handles.
 // ---------------------------------------------------------------------------
 
-class GradientBarWidget : public QWidget
-{
+class GradientBarWidget : public QWidget {
   Q_OBJECT
 
 public:
@@ -35,7 +37,7 @@ public:
   static constexpr int RADIUS = 4;
 
   explicit GradientBarWidget(std::vector<Stop> &stops,
-                             QWidget           *parent = nullptr);
+                             QWidget *parent = nullptr);
 
   void sort_stops();
 
@@ -54,11 +56,11 @@ protected:
 private:
   QRectF bar_rect() const;
   QRectF stop_rect(const Stop &s) const;
-  int    hit_test(const QPoint &pos) const;
+  int hit_test(const QPoint &pos) const;
 
   std::vector<Stop> &stops_;
-  int                selected_idx_ = -1;
-  bool               dragging_ = false;
+  int selected_idx_ = -1;
+  bool dragging_ = false;
 };
 
 // ---------------------------------------------------------------------------
@@ -66,22 +68,26 @@ private:
 //
 // A self-contained gradient editor widget.
 //
-// Top:    Gradient bar with draggable stops (double-click to add/edit,
-//         drag to move, right-click to remove).
-// Bottom: Vertically scrollable grid of preset swatches.
+// Top:     Gradient bar with draggable stops (double-click to add/edit,
+//          drag to move, right-click to remove).
+// Middle:  Toolbar: save the current gradient to the user's GradientLibrary,
+//          import/export gradient files, choose the preset ordering.
+// Bottom:  Vertically scrollable grid of preset swatches merging the host
+//          presets (attribute metadata) with the GradientLibrary. Favourites
+//          are pinned first; right-click a swatch for favourite / rename /
+//          replace / delete / export.
 //
-// The entire content is held within a vertical QScrollArea so that reducing
-// the widget height never squashes or clips the gradient visualization.
+// The grid is held within a vertical QScrollArea so that reducing the widget
+// height never squashes or clips the gradient visualization.
 // ---------------------------------------------------------------------------
 
-class GradientPicker : public QWidget
-{
+class GradientPicker : public QWidget {
   Q_OBJECT
 
 public:
-  explicit GradientPicker(std::vector<Stop>         &stops,
+  explicit GradientPicker(std::vector<Stop> &stops,
                           const std::vector<Preset> &presets,
-                          QWidget                   *parent = nullptr);
+                          QWidget *parent = nullptr);
 
   // Called externally when the attribute's preset list changes.
   void set_presets(const std::vector<Preset> &presets);
@@ -89,28 +95,67 @@ public:
   // Updates the gradient bar visualization from external model changes.
   void update_bar();
 
+  // Stores the current gradient in GradientLibrary::instance() under `name`
+  // (made unique against host presets and the library). Returns the stored
+  // name.
+  std::string save_current_as_preset(const std::string &name);
+
+  // Preset names in display order (favourites first, then the library's sort
+  // key). Exposed for tests and hosts.
+  std::vector<std::string> entry_names() const;
+
 Q_SIGNALS:
   void value_changed(); // every incremental edit
   void edit_ended(); // committed (drag release, colour picked, preset applied)
 
 protected:
-  void  resizeEvent(QResizeEvent *e) override;
-  bool  eventFilter(QObject *watched, QEvent *event) override;
+  void resizeEvent(QResizeEvent *e) override;
+  bool eventFilter(QObject *watched, QEvent *event) override;
   QSize sizeHint() const override;
   QSize minimumSizeHint() const override;
 
 private:
-  void rebuild_preset_grid();
+  struct Entry {
+    Preset preset;
+    bool user = false; // true: GradientLibrary entry, false: host preset
+  };
 
-  std::vector<Stop>  &stops_;
-  std::vector<Preset> presets_;
+  QWidget *build_toolbar();
+  void schedule_rebuild();
+  void rebuild_entries();
+  void rebuild_preset_grid();
+  QPixmap make_swatch(const Entry &entry, bool favorite) const;
+  void apply_stops(const std::vector<Stop> &stops);
+
+  std::vector<std::string> host_names() const;
+
+  void on_save_clicked();
+  void on_import_clicked();
+  void on_export_clicked();
+  void show_entry_menu(Entry entry, const QPoint &global_pos);
+  void export_presets(const std::vector<Preset> &presets,
+                      const QString &suggested_file);
+
+  std::vector<Stop> &stops_;
+  std::vector<Preset> presets_; // host presets (attribute metadata)
+  std::vector<Entry> entries_;  // host + library, display order
 
   GradientBarWidget *bar_widget_ = nullptr;
-  QScrollArea       *scroll_area_ = nullptr;
-  PresetGridWidget  *preset_grid_ = nullptr;
+  QToolButton *save_button_ = nullptr;
+  QToolButton *import_button_ = nullptr;
+  QToolButton *export_button_ = nullptr;
+  QComboBox *sort_combo_ = nullptr;
+  QScrollArea *scroll_area_ = nullptr;
+  PresetGridWidget *preset_grid_ = nullptr;
+  bool rebuild_pending_ = false;
 
-  static constexpr int SWATCH_W = 60; // each preset swatch width
-  static constexpr int SWATCH_H = 32; // each preset swatch height
+  static constexpr int SWATCH_W = 60;  // each preset swatch width
+  static constexpr int SWATCH_H = 32;  // each preset swatch height
+  static constexpr int TOOLBAR_H = 24; // toolbar row height
+
+  // Declared last so it disconnects before the members its callback touches
+  // are destroyed.
+  EventConnection library_connection_;
 };
 
 } // namespace meta::qt

--- a/MetaUI/qt/src/widgets/gradient_picker.cpp
+++ b/MetaUI/qt/src/widgets/gradient_picker.cpp
@@ -2,45 +2,101 @@
    Public License. The full license is in the file LICENSE, distributed with
    this software. */
 #include <algorithm>
+#include <cctype>
 #include <cmath>
+#include <numbers>
 
 #include <QColorDialog>
+#include <QComboBox>
+#include <QFileDialog>
+#include <QFileInfo>
 #include <QGridLayout>
 #include <QHBoxLayout>
+#include <QInputDialog>
 #include <QLabel>
+#include <QLineEdit>
 #include <QMenu>
+#include <QMessageBox>
 #include <QMouseEvent>
 #include <QPainter>
 #include <QPushButton>
 #include <QResizeEvent>
 #include <QScrollArea>
 #include <QScrollBar>
+#include <QSignalBlocker>
+#include <QStandardPaths>
+#include <QToolButton>
 #include <QVBoxLayout>
 
+#include "meta/ext/color_gradient/gradient_library.hpp"
+#include "meta/ext/color_gradient/gradient_metrics.hpp"
 #include "meta/logger.hpp"
 #include "meta_qt/widgets/gradient_picker.hpp"
 
-namespace meta::qt
-{
+namespace meta::qt {
 
 // ---------------------------------------------------------------------------
 // Colour conversion helpers
 // ---------------------------------------------------------------------------
 
-static QColor to_qcolor(const std::array<float, 4> &c)
-{
+static QColor to_qcolor(const std::array<float, 4> &c) {
   return QColor(int(std::clamp(c[0], 0.f, 1.f) * 255.f),
                 int(std::clamp(c[1], 0.f, 1.f) * 255.f),
                 int(std::clamp(c[2], 0.f, 1.f) * 255.f),
                 int(std::clamp(c[3], 0.f, 1.f) * 255.f));
 }
 
-static std::array<float, 4> from_qcolor(const QColor &c)
-{
-  return {float(c.redF()),
-          float(c.greenF()),
-          float(c.blueF()),
+static std::array<float, 4> from_qcolor(const QColor &c) {
+  return {float(c.redF()), float(c.greenF()), float(c.blueF()),
           float(c.alphaF())};
+}
+
+// ---------------------------------------------------------------------------
+// Library helpers
+// ---------------------------------------------------------------------------
+
+// Gives the process-wide GradientLibrary a per-user file on first use, unless
+// the host already chose one (set_path() before any picker exists).
+static void ensure_gradient_library() {
+  GradientLibrary &lib = GradientLibrary::instance();
+  if (!lib.path().empty())
+    return;
+
+  QString dir =
+      QStandardPaths::writableLocation(QStandardPaths::AppConfigLocation);
+  if (dir.isEmpty())
+    dir = QStandardPaths::writableLocation(QStandardPaths::AppDataLocation);
+
+  if (dir.isEmpty()) {
+    static bool warned = false;
+    if (!warned)
+      Logger::log()->warn("GradientPicker: no writable config location, the "
+                          "gradient library will not persist");
+    warned = true;
+    return;
+  }
+
+  lib.set_path(std::filesystem::path(dir.toStdString()) / "gradients.json");
+  lib.load();
+
+  Logger::log()->trace("GradientPicker: gradient library at '{}'",
+                       lib.path().string());
+}
+
+static QString gradient_file_filter() {
+  return QObject::tr("Gradient files (*.json);;All files (*)");
+}
+
+static void draw_star(QPainter &p, const QPointF &center, qreal radius) {
+  QPolygonF star;
+  for (int i = 0; i < 10; ++i) {
+    const qreal r = (i % 2 == 0) ? radius : radius * 0.45;
+    const qreal a = -std::numbers::pi / 2.0 + i * std::numbers::pi / 5.0;
+    star << QPointF(center.x() + r * std::cos(a), center.y() + r * std::sin(a));
+  }
+  p.setPen(QPen(QColor(40, 40, 40), 1));
+  p.setBrush(QColor(255, 200, 40));
+  p.drawPolygon(star);
 }
 
 // ---------------------------------------------------------------------------
@@ -48,26 +104,22 @@ static std::array<float, 4> from_qcolor(const QColor &c)
 // ---------------------------------------------------------------------------
 
 GradientBarWidget::GradientBarWidget(std::vector<Stop> &stops, QWidget *parent)
-    : QWidget(parent), stops_(stops)
-{
+    : QWidget(parent), stops_(stops) {
   setFixedHeight(TOTAL_H);
   setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
 }
 
-void GradientBarWidget::sort_stops()
-{
-  std::sort(stops_.begin(),
-            stops_.end(),
-            [](const Stop &a, const Stop &b)
-            { return a.position < b.position; });
+void GradientBarWidget::sort_stops() {
+  std::sort(stops_.begin(), stops_.end(), [](const Stop &a, const Stop &b) {
+    return a.position < b.position;
+  });
 }
 
-void GradientBarWidget::paintEvent(QPaintEvent *)
-{
+void GradientBarWidget::paintEvent(QPaintEvent *) {
   QPainter p(this);
   p.setRenderHint(QPainter::Antialiasing);
 
-  const QRectF    br = bar_rect();
+  const QRectF br = bar_rect();
   const QPalette &pal = palette();
 
   // Gradient bar
@@ -81,15 +133,14 @@ void GradientBarWidget::paintEvent(QPaintEvent *)
   }
 
   // Stop handles
-  for (int i = 0; i < static_cast<int>(stops_.size()); ++i)
-  {
+  for (int i = 0; i < static_cast<int>(stops_.size()); ++i) {
     const QRectF r = stop_rect(stops_[i]);
-    const bool   sel = (i == selected_idx_);
+    const bool sel = (i == selected_idx_);
 
     // Small triangle pointing up from bar bottom to handle
     const float cx = float(r.center().x());
     const float ty = float(br.bottom());
-    QPolygonF   tri;
+    QPolygonF tri;
     tri << QPointF(cx - 4, ty + 8) << QPointF(cx + 4, ty + 8)
         << QPointF(cx, ty + 1);
     p.setPen(Qt::NoPen);
@@ -105,50 +156,39 @@ void GradientBarWidget::paintEvent(QPaintEvent *)
   }
 }
 
-void GradientBarWidget::mouseDoubleClickEvent(QMouseEvent *e)
-{
+void GradientBarWidget::mouseDoubleClickEvent(QMouseEvent *e) {
   const int idx = hit_test(e->pos());
 
-  if (idx >= 0)
-  {
+  if (idx >= 0) {
     // Edit existing stop colour
     const QColor picked = QColorDialog::getColor(
-        to_qcolor(stops_[idx].color),
-        this,
-        QString(),
+        to_qcolor(stops_[idx].color), this, QString(),
         QColorDialog::ShowAlphaChannel | QColorDialog::DontUseNativeDialog);
 
-    if (picked.isValid())
-    {
+    if (picked.isValid()) {
       stops_[idx].color = from_qcolor(picked);
       update();
       Q_EMIT value_changed();
       Q_EMIT edit_ended();
     }
-  }
-  else if (bar_rect().contains(QPointF(e->pos())))
-  {
+  } else if (bar_rect().contains(QPointF(e->pos()))) {
     // Add new stop
-    const double pos = std::clamp((e->pos().x() - bar_rect().left()) /
-                                      bar_rect().width(),
-                                  0.0,
-                                  1.0);
+    const double pos = std::clamp(
+        (e->pos().x() - bar_rect().left()) / bar_rect().width(), 0.0, 1.0);
 
     constexpr double eps = 1e-3;
-    const bool       too_close = std::any_of(
-        stops_.begin(),
-        stops_.end(),
-        [&](const Stop &s)
-        { return std::abs(double(s.position) - pos) < eps; });
+    const bool too_close =
+        std::any_of(stops_.begin(), stops_.end(), [&](const Stop &s) {
+          return std::abs(double(s.position) - pos) < eps;
+        });
 
-    if (!too_close)
-    {
+    if (!too_close) {
       stops_.push_back({float(pos), {1.f, 1.f, 1.f, 1.f}});
       sort_stops();
-      auto it = std::find_if(stops_.begin(),
-                             stops_.end(),
-                             [pos](const Stop &s)
-                             { return s.position == float(pos); });
+      auto it =
+          std::find_if(stops_.begin(), stops_.end(), [pos](const Stop &s) {
+            return s.position == float(pos);
+          });
       if (it != stops_.end())
         selected_idx_ = static_cast<int>(std::distance(stops_.begin(), it));
       update();
@@ -158,41 +198,36 @@ void GradientBarWidget::mouseDoubleClickEvent(QMouseEvent *e)
   }
 }
 
-void GradientBarWidget::mousePressEvent(QMouseEvent *e)
-{
-  if (e->button() == Qt::LeftButton)
-  {
+void GradientBarWidget::mousePressEvent(QMouseEvent *e) {
+  if (e->button() == Qt::LeftButton) {
     selected_idx_ = hit_test(e->pos());
     dragging_ = selected_idx_ >= 0;
     update();
   }
 }
 
-void GradientBarWidget::mouseMoveEvent(QMouseEvent *e)
-{
+void GradientBarWidget::mouseMoveEvent(QMouseEvent *e) {
   if (!dragging_ || selected_idx_ < 0 ||
       selected_idx_ >= static_cast<int>(stops_.size()))
     return;
 
   const QRectF br = bar_rect();
-  if (br.width() <= 0) return;
+  if (br.width() <= 0)
+    return;
 
-  const double pos = std::clamp((e->pos().x() - br.left()) / br.width(),
-                                0.0,
-                                1.0);
+  const double pos =
+      std::clamp((e->pos().x() - br.left()) / br.width(), 0.0, 1.0);
 
   stops_[selected_idx_].position = float(pos);
 
   // Maintain sorted order while keeping selected_idx_ tracking the moved stop
   while (selected_idx_ > 0 &&
-         stops_[selected_idx_].position < stops_[selected_idx_ - 1].position)
-  {
+         stops_[selected_idx_].position < stops_[selected_idx_ - 1].position) {
     std::swap(stops_[selected_idx_], stops_[selected_idx_ - 1]);
     --selected_idx_;
   }
   while (selected_idx_ + 1 < static_cast<int>(stops_.size()) &&
-         stops_[selected_idx_].position > stops_[selected_idx_ + 1].position)
-  {
+         stops_[selected_idx_].position > stops_[selected_idx_ + 1].position) {
     std::swap(stops_[selected_idx_], stops_[selected_idx_ + 1]);
     ++selected_idx_;
   }
@@ -201,28 +236,26 @@ void GradientBarWidget::mouseMoveEvent(QMouseEvent *e)
   Q_EMIT value_changed();
 }
 
-void GradientBarWidget::mouseReleaseEvent(QMouseEvent *)
-{
-  if (dragging_)
-  {
+void GradientBarWidget::mouseReleaseEvent(QMouseEvent *) {
+  if (dragging_) {
     dragging_ = false;
     Q_EMIT edit_ended();
   }
 }
 
-void GradientBarWidget::contextMenuEvent(QContextMenuEvent *e)
-{
+void GradientBarWidget::contextMenuEvent(QContextMenuEvent *e) {
   const int idx = hit_test(e->pos());
-  if (idx < 0) return;
+  if (idx < 0)
+    return;
 
   // Only offer removal when at least 3 stops (keep minimum 2).
-  if (static_cast<int>(stops_.size()) <= 2) return;
+  if (static_cast<int>(stops_.size()) <= 2)
+    return;
 
-  QMenu    menu(this);
+  QMenu menu(this);
   QAction *rm = menu.addAction(QObject::tr("Remove stop"));
 
-  if (menu.exec(e->globalPos()) == rm)
-  {
+  if (menu.exec(e->globalPos()) == rm) {
     stops_.erase(stops_.begin() + idx);
 
     if (selected_idx_ == idx)
@@ -236,21 +269,18 @@ void GradientBarWidget::contextMenuEvent(QContextMenuEvent *e)
   }
 }
 
-QRectF GradientBarWidget::bar_rect() const
-{
+QRectF GradientBarWidget::bar_rect() const {
   return QRectF(PAD, PAD, width() - 2 * PAD, BAR_H);
 }
 
-QRectF GradientBarWidget::stop_rect(const Stop &s) const
-{
+QRectF GradientBarWidget::stop_rect(const Stop &s) const {
   const QRectF br = bar_rect();
   const double cx = br.left() + double(s.position) * br.width();
   const double cy = br.bottom() + 3 + STOP_R;
   return QRectF(cx - STOP_R, cy - STOP_R, STOP_R * 2, STOP_R * 2);
 }
 
-int GradientBarWidget::hit_test(const QPoint &pos) const
-{
+int GradientBarWidget::hit_test(const QPoint &pos) const {
   for (int i = static_cast<int>(stops_.size()) - 1; i >= 0; --i)
     if (stop_rect(stops_[i]).adjusted(-2, -2, 2, 2).contains(QPointF(pos)))
       return i;
@@ -261,18 +291,12 @@ int GradientBarWidget::hit_test(const QPoint &pos) const
 // PresetGridWidget: responsive grid that wraps swatches based on width
 // ---------------------------------------------------------------------------
 
-class PresetGridWidget : public QWidget
-{
+class PresetGridWidget : public QWidget {
 public:
-  explicit PresetGridWidget(int      swatch_w,
-                            int      swatch_h,
-                            int      spacing = 4,
+  explicit PresetGridWidget(int swatch_w, int swatch_h, int spacing = 4,
                             QWidget *parent = nullptr)
-      : QWidget(parent),
-        swatch_w_(swatch_w),
-        swatch_h_(swatch_h),
-        spacing_(spacing)
-  {
+      : QWidget(parent), swatch_w_(swatch_w), swatch_h_(swatch_h),
+        spacing_(spacing) {
     // Tell the layout system that our height depends on our width, so
     // QVBoxLayout / QScrollArea can query heightForWidth() instead of
     // relying on a stale, width-independent sizeHint().
@@ -283,20 +307,18 @@ public:
     init_layout();
   }
 
-  void set_buttons(const std::vector<QPushButton *> &buttons)
-  {
+  void set_buttons(const std::vector<QPushButton *> &buttons) {
     buttons_ = buttons;
     current_cols_ = -1;
     reflow(width());
   }
 
-  void reflow(int avail_w)
-  {
-    if (buttons_.empty()) return;
+  void reflow(int avail_w) {
+    if (buttons_.empty())
+      return;
 
     const int cols = compute_cols(avail_w);
-    if (cols == current_cols_)
-    {
+    if (cols == current_cols_) {
       const int h = heightForWidth(avail_w);
       setMinimumHeight(h);
       return;
@@ -309,8 +331,7 @@ public:
     init_layout();
 
     for (size_t i = 0; i < buttons_.size(); ++i)
-      grid_->addWidget(buttons_[i],
-                       static_cast<int>(i / cols),
+      grid_->addWidget(buttons_[i], static_cast<int>(i / cols),
                        static_cast<int>(i % cols));
 
     const int h = heightForWidth(avail_w);
@@ -320,46 +341,43 @@ public:
 
   bool hasHeightForWidth() const override { return true; }
 
-  int heightForWidth(int w) const override
-  {
-    if (buttons_.empty()) return 0;
+  int heightForWidth(int w) const override {
+    if (buttons_.empty())
+      return 0;
     const int cols = compute_cols(w);
     const int rows = (static_cast<int>(buttons_.size()) + cols - 1) / cols;
     return 4 + rows * swatch_h_ + (rows - 1) * spacing_;
   }
 
-  QSize sizeHint() const override
-  {
-    if (buttons_.empty()) return QSize(0, 0);
+  QSize sizeHint() const override {
+    if (buttons_.empty())
+      return QSize(0, 0);
     const int cols = current_cols_ > 0 ? current_cols_ : 1;
     const int w = 4 + cols * swatch_w_ + (cols - 1) * spacing_;
     return QSize(w, heightForWidth(width() > 0 ? width() : w));
   }
 
-  QSize minimumSizeHint() const override
-  {
-    if (buttons_.empty()) return QSize(0, 0);
+  QSize minimumSizeHint() const override {
+    if (buttons_.empty())
+      return QSize(0, 0);
     return QSize(swatch_w_ + 4,
                  heightForWidth(width() > 0 ? width() : swatch_w_ + 4));
   }
 
 protected:
-  void resizeEvent(QResizeEvent *event) override
-  {
+  void resizeEvent(QResizeEvent *event) override {
     QWidget::resizeEvent(event);
     reflow(event->size().width());
   }
 
 private:
-  int compute_cols(int avail_w) const
-  {
+  int compute_cols(int avail_w) const {
     const int margins_w = 4;
     return std::max(1,
                     (avail_w - margins_w + spacing_) / (swatch_w_ + spacing_));
   }
 
-  void init_layout()
-  {
+  void init_layout() {
     grid_ = new QGridLayout(this);
     grid_->setContentsMargins(2, 2, 2, 2);
     grid_->setSpacing(spacing_);
@@ -367,11 +385,11 @@ private:
     grid_->setSizeConstraint(QLayout::SetNoConstraint);
   }
 
-  int                        swatch_w_;
-  int                        swatch_h_;
-  int                        spacing_;
-  int                        current_cols_ = -1;
-  QGridLayout               *grid_ = nullptr;
+  int swatch_w_;
+  int swatch_h_;
+  int spacing_;
+  int current_cols_ = -1;
+  QGridLayout *grid_ = nullptr;
   std::vector<QPushButton *> buttons_;
 };
 
@@ -379,11 +397,12 @@ private:
 // Constructor
 // ---------------------------------------------------------------------------
 
-GradientPicker::GradientPicker(std::vector<Stop>         &stops,
+GradientPicker::GradientPicker(std::vector<Stop> &stops,
                                const std::vector<Preset> &presets,
-                               QWidget                   *parent)
-    : QWidget(parent), stops_(stops), presets_(presets)
-{
+                               QWidget *parent)
+    : QWidget(parent), stops_(stops), presets_(presets) {
+  ensure_gradient_library();
+
   setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
 
   auto *main_layout = new QVBoxLayout(this);
@@ -393,6 +412,9 @@ GradientPicker::GradientPicker(std::vector<Stop>         &stops,
   // Gradient bar pinned at the top (fixed height, never scrolls)
   bar_widget_ = new GradientBarWidget(stops_, this);
   main_layout->addWidget(bar_widget_);
+
+  // Library toolbar
+  main_layout->addWidget(build_toolbar());
 
   // Preset selection grid inside scroll area
   scroll_area_ = new QScrollArea(this);
@@ -410,94 +432,256 @@ GradientPicker::GradientPicker(std::vector<Stop>         &stops,
 
   main_layout->addWidget(scroll_area_, 1);
 
-  connect(bar_widget_,
-          &GradientBarWidget::value_changed,
-          this,
+  connect(bar_widget_, &GradientBarWidget::value_changed, this,
           &GradientPicker::value_changed);
-  connect(bar_widget_,
-          &GradientBarWidget::edit_ended,
-          this,
+  connect(bar_widget_, &GradientBarWidget::edit_ended, this,
           &GradientPicker::edit_ended);
 
+  // Any picker (or the host) editing the library refreshes this grid
+  library_connection_ = GradientLibrary::instance().changed.subscribe(
+      [this]() { schedule_rebuild(); });
+
   rebuild_preset_grid();
+}
+
+// ---------------------------------------------------------------------------
+// Toolbar
+// ---------------------------------------------------------------------------
+
+QWidget *GradientPicker::build_toolbar() {
+  auto *bar = new QWidget(this);
+  auto *layout = new QHBoxLayout(bar);
+  layout->setContentsMargins(0, 0, 0, 0);
+  layout->setSpacing(4);
+
+  const auto make_button = [bar](const QString &text, const QString &tip) {
+    auto *button = new QToolButton(bar);
+    button->setText(text);
+    button->setToolTip(tip);
+    button->setAutoRaise(true);
+    button->setToolButtonStyle(Qt::ToolButtonTextOnly);
+    button->setFixedHeight(TOOLBAR_H);
+    button->setCursor(Qt::PointingHandCursor);
+    return button;
+  };
+
+  save_button_ = make_button(tr("Save..."),
+                             tr("Save the current gradient to your library"));
+  import_button_ =
+      make_button(tr("Import..."), tr("Import gradients from JSON files"));
+  export_button_ =
+      make_button(tr("Export..."), tr("Export your library to a JSON file"));
+
+  connect(save_button_, &QToolButton::clicked, this,
+          &GradientPicker::on_save_clicked);
+  connect(import_button_, &QToolButton::clicked, this,
+          &GradientPicker::on_import_clicked);
+  connect(export_button_, &QToolButton::clicked, this,
+          &GradientPicker::on_export_clicked);
+
+  sort_combo_ = new QComboBox(bar);
+  sort_combo_->setToolTip(tr("Preset ordering (favorites always come first)"));
+  sort_combo_->setFixedHeight(TOOLBAR_H);
+  // item order == meta::GradientSort
+  sort_combo_->addItems(
+      {tr("Default"), tr("Name"), tr("Luminance"), tr("Hue")});
+
+  // `activated` fires for user picks only, so syncing the index from the
+  // library in rebuild_preset_grid() cannot loop back.
+  connect(sort_combo_, QOverload<int>::of(&QComboBox::activated), this,
+          [](int index) {
+            GradientLibrary::instance().set_sort(
+                static_cast<GradientSort>(index));
+          });
+
+  layout->addWidget(save_button_);
+  layout->addWidget(import_button_);
+  layout->addWidget(export_button_);
+  layout->addStretch(1);
+  layout->addWidget(new QLabel(tr("Sort"), bar));
+  layout->addWidget(sort_combo_);
+
+  return bar;
 }
 
 // ---------------------------------------------------------------------------
 // Preset grid
 // ---------------------------------------------------------------------------
 
-void GradientPicker::set_presets(const std::vector<Preset> &presets)
-{
+void GradientPicker::set_presets(const std::vector<Preset> &presets) {
   presets_ = presets;
   rebuild_preset_grid();
 }
 
-void GradientPicker::update_bar()
-{
-  if (bar_widget_) bar_widget_->update();
+void GradientPicker::update_bar() {
+  if (bar_widget_)
+    bar_widget_->update();
 }
 
-void GradientPicker::rebuild_preset_grid()
-{
-  scroll_area_->setVisible(!presets_.empty());
+void GradientPicker::schedule_rebuild() {
+  // Deferred: the notification may come from a slot of a swatch button that
+  // the rebuild is about to delete, and bursts (imports) coalesce.
+  if (rebuild_pending_)
+    return;
+  rebuild_pending_ = true;
 
-  // Delete all existing child buttons inside preset_grid_
-  qDeleteAll(
-      preset_grid_->findChildren<QPushButton *>(QString(),
-                                                Qt::FindDirectChildrenOnly));
+  QMetaObject::invokeMethod(
+      this,
+      [this]() {
+        rebuild_pending_ = false;
+        rebuild_preset_grid();
+      },
+      Qt::QueuedConnection);
+}
 
-  std::vector<QPushButton *> buttons;
-  buttons.reserve(presets_.size());
+void GradientPicker::rebuild_entries() {
+  const GradientLibrary &lib = GradientLibrary::instance();
+  const GradientSort sort = lib.sort();
+
+  struct Keyed {
+    Entry entry;
+    bool favorite;
+    float key;
+    std::string lower_name;
+    std::size_t index;
+  };
+
+  std::vector<Keyed> keyed;
+  keyed.reserve(presets_.size() + lib.presets().size());
+
+  const auto push = [&](const Preset &preset, bool user) {
+    Keyed k{Entry{preset, user}, lib.is_favorite(preset.name), 0.f, preset.name,
+            keyed.size()};
+
+    std::transform(k.lower_name.begin(), k.lower_name.end(),
+                   k.lower_name.begin(),
+                   [](unsigned char c) { return char(std::tolower(c)); });
+
+    if (sort == GradientSort::Luminance)
+      k.key = gradient_luminance(preset.stops);
+    else if (sort == GradientSort::Hue) {
+      const float hue = gradient_hue(preset.stops);
+      k.key = hue < 0.f ? 1e6f : hue; // achromatic last
+    }
+
+    keyed.push_back(std::move(k));
+  };
 
   for (const auto &preset : presets_)
-  {
-    QPixmap pix(SWATCH_W, SWATCH_H);
-    {
-      QPainter pp(&pix);
-      pp.setRenderHint(QPainter::Antialiasing);
+    push(preset, false);
+  for (const auto &preset : lib.presets())
+    push(preset, true);
 
-      QLinearGradient grad(0, 0, pix.width(), 0);
-      for (const auto &s : preset.stops)
-        grad.setColorAt(double(s.position), to_qcolor(s.color));
-      pp.fillRect(pix.rect(), grad);
+  std::stable_sort(keyed.begin(), keyed.end(),
+                   [sort](const Keyed &a, const Keyed &b) {
+                     if (a.favorite != b.favorite)
+                       return a.favorite;
 
-      // Name overlay
-      pp.setPen(Qt::white);
-      pp.setFont(QFont(pp.font().family(), 7));
-      pp.drawText(pix.rect().adjusted(2, 0, -2, 0),
-                  Qt::AlignBottom | Qt::AlignHCenter,
-                  QString::fromStdString(preset.name));
+                     switch (sort) {
+                     case GradientSort::Name:
+                       return a.lower_name < b.lower_name;
+                     case GradientSort::Luminance:
+                     case GradientSort::Hue:
+                       if (a.key != b.key)
+                         return a.key < b.key;
+                       return a.lower_name < b.lower_name;
+                     case GradientSort::Default:
+                     default:
+                       return a.index < b.index;
+                     }
+                   });
 
-      // Border
-      pp.setPen(QPen(QColor(80, 80, 80), 1));
-      pp.setBrush(Qt::NoBrush);
-      pp.drawRoundedRect(pix.rect().adjusted(0, 0, -1, -1),
-                         GradientBarWidget::RADIUS,
-                         GradientBarWidget::RADIUS);
-    }
+  entries_.clear();
+  entries_.reserve(keyed.size());
+  for (auto &k : keyed)
+    entries_.push_back(std::move(k.entry));
+}
+
+QPixmap GradientPicker::make_swatch(const Entry &entry, bool favorite) const {
+  QPixmap pix(SWATCH_W, SWATCH_H);
+  QPainter pp(&pix);
+  pp.setRenderHint(QPainter::Antialiasing);
+
+  QLinearGradient grad(0, 0, pix.width(), 0);
+  for (const auto &s : entry.preset.stops)
+    grad.setColorAt(double(s.position), to_qcolor(s.color));
+  pp.fillRect(pix.rect(), grad);
+
+  // Name overlay
+  pp.setPen(Qt::white);
+  pp.setFont(QFont(pp.font().family(), 7));
+  pp.drawText(pix.rect().adjusted(2, 0, -2, 0),
+              Qt::AlignBottom | Qt::AlignHCenter,
+              QString::fromStdString(entry.preset.name));
+
+  // Favourite star (top-left) and library marker (top-right)
+  if (favorite)
+    draw_star(pp, QPointF(8, 8), 5.5);
+
+  if (entry.user) {
+    pp.setPen(QPen(QColor(40, 40, 40), 1));
+    pp.setBrush(Qt::white);
+    pp.drawEllipse(QPointF(pix.width() - 7, 7), 3, 3);
+  }
+
+  // Border
+  pp.setPen(QPen(QColor(80, 80, 80), 1));
+  pp.setBrush(Qt::NoBrush);
+  pp.drawRoundedRect(pix.rect().adjusted(0, 0, -1, -1),
+                     GradientBarWidget::RADIUS, GradientBarWidget::RADIUS);
+
+  return pix;
+}
+
+void GradientPicker::rebuild_preset_grid() {
+  const GradientLibrary &lib = GradientLibrary::instance();
+
+  rebuild_entries();
+
+  if (sort_combo_) {
+    const QSignalBlocker blocker(sort_combo_);
+    sort_combo_->setCurrentIndex(static_cast<int>(lib.sort()));
+  }
+  if (export_button_)
+    export_button_->setEnabled(!lib.presets().empty());
+
+  scroll_area_->setVisible(!entries_.empty());
+
+  // Delete all existing child buttons inside preset_grid_
+  qDeleteAll(preset_grid_->findChildren<QPushButton *>(
+      QString(), Qt::FindDirectChildrenOnly));
+
+  std::vector<QPushButton *> buttons;
+  buttons.reserve(entries_.size());
+
+  for (std::size_t i = 0; i < entries_.size(); ++i) {
+    const Entry &entry = entries_[i];
+    const bool favorite = lib.is_favorite(entry.preset.name);
+    const QString name = QString::fromStdString(entry.preset.name);
 
     auto *btn = new QPushButton(preset_grid_);
     btn->setFixedSize(SWATCH_W, SWATCH_H);
     btn->setFlat(true);
-    btn->setIcon(QIcon(pix));
+    btn->setIcon(QIcon(make_swatch(entry, favorite)));
     btn->setIconSize(QSize(SWATCH_W, SWATCH_H));
-    btn->setToolTip(QString::fromStdString(preset.name));
+    btn->setToolTip(
+        QString("%1\n%2, %3 %4")
+            .arg(name, entry.user ? tr("Library preset") : tr("Preset"))
+            .arg(int(entry.preset.stops.size()))
+            .arg(tr("stops")));
     btn->setCursor(Qt::PointingHandCursor);
+    btn->setProperty("preset_name", name);
+    btn->setProperty("preset_user", entry.user);
+    btn->setContextMenuPolicy(Qt::CustomContextMenu);
 
-    const std::vector<Stop> preset_stops = preset.stops;
-    connect(btn,
-            &QPushButton::clicked,
-            this,
-            [this, preset_stops]()
-            {
-              stops_ = preset_stops;
-              if (bar_widget_)
-              {
-                bar_widget_->sort_stops();
-                bar_widget_->update();
-              }
-              Q_EMIT value_changed();
-              Q_EMIT edit_ended();
+    const std::vector<Stop> preset_stops = entry.preset.stops;
+    connect(btn, &QPushButton::clicked, this,
+            [this, preset_stops]() { apply_stops(preset_stops); });
+
+    connect(btn, &QPushButton::customContextMenuRequested, this,
+            [this, btn, i](const QPoint &pos) {
+              if (i < entries_.size())
+                show_entry_menu(entries_[i], btn->mapToGlobal(pos));
             });
 
     buttons.push_back(btn);
@@ -506,40 +690,200 @@ void GradientPicker::rebuild_preset_grid()
   preset_grid_->set_buttons(buttons);
   if (scroll_area_ && scroll_area_->viewport())
     preset_grid_->reflow(scroll_area_->viewport()->width());
+
+  updateGeometry();
 }
 
-void GradientPicker::resizeEvent(QResizeEvent *e)
-{
+void GradientPicker::apply_stops(const std::vector<Stop> &stops) {
+  stops_ = stops;
+  if (bar_widget_) {
+    bar_widget_->sort_stops();
+    bar_widget_->update();
+  }
+  Q_EMIT value_changed();
+  Q_EMIT edit_ended();
+}
+
+std::vector<std::string> GradientPicker::host_names() const {
+  std::vector<std::string> names;
+  names.reserve(presets_.size());
+  for (const auto &preset : presets_)
+    names.push_back(preset.name);
+  return names;
+}
+
+std::vector<std::string> GradientPicker::entry_names() const {
+  std::vector<std::string> names;
+  names.reserve(entries_.size());
+  for (const auto &entry : entries_)
+    names.push_back(entry.preset.name);
+  return names;
+}
+
+// ---------------------------------------------------------------------------
+// Library actions
+// ---------------------------------------------------------------------------
+
+std::string GradientPicker::save_current_as_preset(const std::string &name) {
+  GradientLibrary &lib = GradientLibrary::instance();
+
+  Preset preset;
+  preset.name = lib.unique_name(name, host_names());
+  preset.stops = stops_;
+
+  return lib.add(std::move(preset));
+}
+
+void GradientPicker::on_save_clicked() {
+  GradientLibrary &lib = GradientLibrary::instance();
+
+  bool ok = false;
+  const QString text = QInputDialog::getText(
+      this, tr("Save gradient"), tr("Preset name:"), QLineEdit::Normal,
+      QString::fromStdString(lib.unique_name("Gradient", host_names())), &ok);
+
+  if (!ok || text.trimmed().isEmpty())
+    return;
+
+  save_current_as_preset(text.trimmed().toStdString());
+}
+
+void GradientPicker::on_import_clicked() {
+  const QStringList files = QFileDialog::getOpenFileNames(
+      this, tr("Import gradients"), QString(), gradient_file_filter());
+  if (files.isEmpty())
+    return;
+
+  GradientLibrary &lib = GradientLibrary::instance();
+  QStringList failed;
+  std::size_t imported = 0;
+
+  for (const QString &file : files) {
+    const GradientImportReport report =
+        lib.import_file(std::filesystem::path(file.toStdString()));
+    if (!report.ok)
+      failed << QFileInfo(file).fileName();
+    else
+      imported += report.added + report.renamed;
+  }
+
+  Logger::log()->trace("GradientPicker::on_import_clicked: {} imported from "
+                       "{} file(s), {} failed",
+                       imported, files.size(), failed.size());
+
+  if (!failed.isEmpty())
+    QMessageBox::warning(
+        this, tr("Import gradients"),
+        tr("No gradients could be read from:\n%1").arg(failed.join('\n')));
+}
+
+void GradientPicker::on_export_clicked() {
+  export_presets(GradientLibrary::instance().presets(), "gradients.json");
+}
+
+void GradientPicker::export_presets(const std::vector<Preset> &presets,
+                                    const QString &suggested_file) {
+  QString file = QFileDialog::getSaveFileName(
+      this, tr("Export gradients"), suggested_file, gradient_file_filter());
+  if (file.isEmpty())
+    return;
+  if (!file.endsWith(".json", Qt::CaseInsensitive))
+    file += ".json";
+
+  if (!GradientLibrary::instance().export_file(
+          std::filesystem::path(file.toStdString()), presets))
+    QMessageBox::warning(this, tr("Export gradients"),
+                         tr("Could not write \"%1\".").arg(file));
+}
+
+void GradientPicker::show_entry_menu(Entry entry, const QPoint &global_pos) {
+  // `entry` is a copy on purpose: the menu runs a nested event loop during
+  // which entries_ may be rebuilt.
+  GradientLibrary &lib = GradientLibrary::instance();
+  const std::string name = entry.preset.name;
+
+  QMenu menu(this);
+
+  QAction *favorite =
+      menu.addAction(lib.is_favorite(name) ? tr("Remove from favorites")
+                                           : tr("Add to favorites"));
+
+  QAction *rename = nullptr;
+  QAction *replace = nullptr;
+  QAction *remove = nullptr;
+  if (entry.user) {
+    menu.addSeparator();
+    rename = menu.addAction(tr("Rename..."));
+    replace = menu.addAction(tr("Replace with current gradient"));
+    remove = menu.addAction(tr("Delete"));
+  }
+
+  menu.addSeparator();
+  QAction *export_action = menu.addAction(tr("Export..."));
+
+  QAction *chosen = menu.exec(global_pos);
+  if (!chosen)
+    return;
+
+  if (chosen == favorite) {
+    lib.set_favorite(name, !lib.is_favorite(name));
+  } else if (chosen == rename) {
+    bool ok = false;
+    const QString text = QInputDialog::getText(
+        this, tr("Rename gradient"), tr("New name:"), QLineEdit::Normal,
+        QString::fromStdString(name), &ok);
+    if (!ok || text.trimmed().isEmpty())
+      return;
+
+    if (!lib.rename(name, text.trimmed().toStdString()))
+      QMessageBox::warning(
+          this, tr("Rename gradient"),
+          tr("A gradient named \"%1\" already exists.").arg(text.trimmed()));
+  } else if (chosen == replace) {
+    lib.update(name, stops_);
+  } else if (chosen == remove) {
+    const auto answer =
+        QMessageBox::question(this, tr("Delete gradient"),
+                              tr("Delete \"%1\" from your library?")
+                                  .arg(QString::fromStdString(name)));
+    if (answer == QMessageBox::Yes)
+      lib.remove(name);
+  } else if (chosen == export_action) {
+    export_presets({entry.preset}, QString::fromStdString(name) + ".json");
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Geometry
+// ---------------------------------------------------------------------------
+
+void GradientPicker::resizeEvent(QResizeEvent *e) {
   QWidget::resizeEvent(e);
-  if (scroll_area_ && scroll_area_->viewport() && preset_grid_)
-  {
+  if (scroll_area_ && scroll_area_->viewport() && preset_grid_) {
     preset_grid_->reflow(scroll_area_->viewport()->width());
   }
 }
 
-bool GradientPicker::eventFilter(QObject *watched, QEvent *event)
-{
+bool GradientPicker::eventFilter(QObject *watched, QEvent *event) {
   if (scroll_area_ && watched == scroll_area_->viewport() &&
-      event->type() == QEvent::Resize)
-  {
+      event->type() == QEvent::Resize) {
     auto *re = static_cast<QResizeEvent *>(event);
-    if (preset_grid_) preset_grid_->reflow(re->size().width());
+    if (preset_grid_)
+      preset_grid_->reflow(re->size().width());
   }
   return QWidget::eventFilter(watched, event);
 }
 
-QSize GradientPicker::sizeHint() const
-{
-  const int top_h = GradientBarWidget::TOTAL_H;
-  const int preset_h = presets_.empty() ? 0 : (SWATCH_H + 4) * 3 + 8;
-  return {300, top_h + (presets_.empty() ? 0 : 4 + preset_h)};
+QSize GradientPicker::sizeHint() const {
+  const int top_h = GradientBarWidget::TOTAL_H + 4 + TOOLBAR_H;
+  const int preset_h = entries_.empty() ? 0 : (SWATCH_H + 4) * 3 + 8;
+  return {300, top_h + (entries_.empty() ? 0 : 4 + preset_h)};
 }
 
-QSize GradientPicker::minimumSizeHint() const
-{
-  const int top_h = GradientBarWidget::TOTAL_H;
-  const int preset_h = presets_.empty() ? 0 : SWATCH_H + 8;
-  return {120, top_h + (presets_.empty() ? 0 : 4 + preset_h)};
+QSize GradientPicker::minimumSizeHint() const {
+  const int top_h = GradientBarWidget::TOTAL_H + 4 + TOOLBAR_H;
+  const int preset_h = entries_.empty() ? 0 : SWATCH_H + 8;
+  return {160, top_h + (entries_.empty() ? 0 : 4 + preset_h)};
 }
 
 } // namespace meta::qt

--- a/MetaUI/qt/src/widgets/gradient_picker.cpp
+++ b/MetaUI/qt/src/widgets/gradient_picker.cpp
@@ -431,6 +431,9 @@ GradientPicker::GradientPicker(std::vector<Stop> &stops,
     scroll_area_->viewport()->installEventFilter(this);
 
   main_layout->addWidget(scroll_area_, 1);
+  // Absorbs the freed space when the grid is hidden (no presets at all), so
+  // the toolbar stays under the bar instead of floating mid-widget.
+  main_layout->addStretch(0);
 
   connect(bar_widget_, &GradientBarWidget::value_changed, this,
           &GradientPicker::value_changed);

--- a/README.md
+++ b/README.md
@@ -43,6 +43,46 @@ This builds:
 | `META_ENABLE_FTXUI_UI`             | Enable FTXUI UI backend *(stub implementation)* | OFF     |
 | `META_ENABLE_QT_UI`                | Enable Qt UI backend                            | OFF     |
 
+## Gradient library
+
+`meta::ColorGradient` attributes render a `GradientPicker` whose preset grid
+shows two sources: host presets installed in attribute metadata
+(`keys::ui::presets` → `meta::GradientPresets`) and the user's own
+**gradient library** (`meta::GradientLibrary::instance()`), which persists
+across projects. From the picker the user can save the current gradient to the
+library, import/export gradient files, pin favorites (always shown first) and
+sort by name, luminance or hue. Library entries can be renamed, replaced with
+the current gradient or deleted from the swatch context menu.
+
+The library autosaves to a JSON file. The Qt picker picks a default location on
+first use (`QStandardPaths::AppConfigLocation/gradients.json`, falling back to
+`AppDataLocation`); a host can choose its own before any picker exists:
+
+```cpp
+auto &library = meta::GradientLibrary::instance();
+library.set_path(my_config_dir / "gradients.json");
+library.load();
+```
+
+Gradient files use the same document for the library, exports and imports:
+
+```json
+{
+  "format": "meta.gradients",
+  "version": 1,
+  "gradients": [
+    {"name": "Snow", "stops": [{"position": 0.0, "color": [0.78, 0.86, 1.0, 1.0]},
+                               {"position": 1.0, "color": [1.0, 1.0, 1.0, 1.0]}]}
+  ]
+}
+```
+
+The reader also accepts a bare array of gradients, a single gradient object,
+stops under `"value"` (the `ColorGradient::json_to()` shape) and 0–255 colour
+components, so existing per-gradient JSON assets import directly. Imports never
+prompt: identical duplicates are skipped and clashing names get a `" (2)"`
+suffix.
+
 > **FTXUI backend is currently a stub used for testing and experimental integration only. It is not a complete UI implementation.**
 
 ## Example configurations

--- a/docs/builtin_types.md
+++ b/docs/builtin_types.md
@@ -38,5 +38,5 @@
 | std::vector<float> | Qt | CurveEditor (default) | Interactive 2D curve canvas editor. | label, curve_size, min_x, max_x, min_y, max_y |
 | std::vector<glm::vec3> | Qt | PointsEditor (default) | Interactive 2D/3D points canvas editor with toolbar actions and background image provider. | label, min_x, max_x, min_y, max_y, z_step, closed, data_provider |
 | std::vector<glm::vec3> | Qt | PathEditor | Interactive connected path editor canvas with toolbar actions and background image provider. | label, min_x, max_x, min_y, max_y, z_step, closed, data_provider |
-| meta::ColorGradient | Qt | GradientEditor (default) | Interactive color gradient picker with stops and presets. | label, presets |
+| meta::ColorGradient | Qt | GradientEditor (default) | Interactive color gradient picker with stops; preset grid merges host presets with the user's persistent gradient library (save / import / export / favorites / sort by name, luminance or hue). | label, presets |
 | meta::Array | Qt | ArrayEditor (default) | 2D array drawing canvas with background image provider support. | label, width, height, data_provider |

--- a/tests/test_qt/gradient_picker_snap/CMakeLists.txt
+++ b/tests/test_qt/gradient_picker_snap/CMakeLists.txt
@@ -1,0 +1,2 @@
+add_executable(gradient_picker_snap main.cpp)
+target_link_libraries(gradient_picker_snap meta meta_qt)

--- a/tests/test_qt/gradient_picker_snap/main.cpp
+++ b/tests/test_qt/gradient_picker_snap/main.cpp
@@ -1,0 +1,82 @@
+// Offscreen snapshot harness for GradientPicker (issue #50). Renders the
+// widget with host presets plus an isolated gradient library (favourites,
+// user entries, each sort key) to PNG files for visual review. Not part of
+// the test suite; run with QT_QPA_PLATFORM=offscreen.
+#include <filesystem>
+#include <vector>
+
+#include <QApplication>
+#include <QDir>
+
+#include "meta/ext/color_gradient/gradient_library.hpp"
+#include "meta_qt/widgets/gradient_picker.hpp"
+
+using meta::GradientLibrary;
+using meta::GradientSort;
+using meta::Preset;
+using meta::Stop;
+
+static Preset make(const std::string &name, std::vector<Stop> stops) {
+  return {name, std::move(stops)};
+}
+
+static void snap(QWidget &w, const QString &path) {
+  w.resize(320, 260);
+  w.grab().save(path);
+}
+
+int main(int argc, char **argv) {
+  QApplication app(argc, argv);
+  const QString dir = argc > 1 ? argv[1] : ".";
+  QDir().mkpath(dir);
+
+  // Isolated library so the snapshot never touches a real per-user file
+  GradientLibrary &lib = GradientLibrary::instance();
+  lib.set_path(std::filesystem::temp_directory_path() /
+               "meta_gradient_picker_snap" / "gradients.json");
+  lib.clear();
+
+  const std::vector<Preset> host = {
+      make("Snow",
+           {{0.f, {0.78f, 0.86f, 1.f, 1.f}}, {1.f, {1.f, 1.f, 1.f, 1.f}}}),
+      make("Sand",
+           {{0.f, {0.76f, 0.7f, 0.5f, 1.f}}, {1.f, {0.94f, 0.9f, 0.7f, 1.f}}}),
+      make("Grass", {{0.f, {0.12f, 0.27f, 0.12f, 1.f}},
+                     {1.f, {0.5f, 0.75f, 0.3f, 1.f}}}),
+      make("Ocean",
+           {{0.f, {0.f, 0.05f, 0.25f, 1.f}}, {1.f, {0.2f, 0.6f, 0.9f, 1.f}}}),
+      make("Lava", {{0.f, {0.1f, 0.f, 0.f, 1.f}},
+                    {0.6f, {0.9f, 0.2f, 0.f, 1.f}},
+                    {1.f, {1.f, 0.9f, 0.3f, 1.f}}}),
+      make("Greys",
+           {{0.f, {0.f, 0.f, 0.f, 1.f}}, {1.f, {1.f, 1.f, 1.f, 1.f}}})};
+
+  lib.add(make("My sunset", {{0.f, {0.2f, 0.f, 0.3f, 1.f}},
+                             {0.5f, {0.9f, 0.3f, 0.2f, 1.f}},
+                             {1.f, {1.f, 0.8f, 0.4f, 1.f}}}));
+  lib.add(make("Mint", {{0.f, {0.f, 0.3f, 0.25f, 1.f}},
+                        {1.f, {0.6f, 1.f, 0.85f, 1.f}}}));
+  lib.set_favorite("Ocean", true);
+  lib.set_favorite("Mint", true);
+
+  std::vector<Stop> stops = {{0.f, {0.1f, 0.1f, 0.3f, 1.f}},
+                             {0.5f, {0.9f, 0.5f, 0.1f, 1.f}},
+                             {1.f, {1.f, 1.f, 0.8f, 1.f}}};
+
+  for (GradientSort sort : {GradientSort::Default, GradientSort::Name,
+                            GradientSort::Luminance, GradientSort::Hue}) {
+    lib.set_sort(sort);
+    meta::qt::GradientPicker picker(stops, host);
+    snap(picker,
+         dir + "/sort_" +
+             QString::fromStdString(std::string(meta::to_string(sort))) +
+             ".png");
+  }
+
+  // No host presets, empty library: bar + toolbar only
+  lib.clear();
+  meta::qt::GradientPicker bare(stops, {});
+  snap(bare, dir + "/empty.png");
+
+  return 0;
+}

--- a/tests/test_qt/test_meta_qt/main.cpp
+++ b/tests/test_qt/test_meta_qt/main.cpp
@@ -873,6 +873,16 @@ int main(int argc, char *argv[])
 
   const bool base_groups = true;
 
+#ifdef META_ENABLE_COLOR_GRADIENT_TYPES
+  // Keep manual runs away from the real per-user gradient library.
+  {
+    auto &library = meta::GradientLibrary::instance();
+    library.set_path(std::filesystem::temp_directory_path() /
+                     "meta_test_gradients.json");
+    library.load();
+  }
+#endif
+
   // ---------------------------------------------------------------------------
   // Containers
   // ---------------------------------------------------------------------------

--- a/tests/unittests/CMakeLists.txt
+++ b/tests/unittests/CMakeLists.txt
@@ -35,7 +35,7 @@ set(UNITTEST_LIBS
 
 if(META_ENABLE_QT_UI)
   set(CMAKE_AUTOMOC ON)
-  list(APPEND UNITTEST_SOURCES test_design_registry.cpp)
+  list(APPEND UNITTEST_SOURCES test_design_registry.cpp test_gradient_picker.cpp)
   list(APPEND UNITTEST_LIBS meta_qt)
   find_package(Qt6 REQUIRED COMPONENTS Core Widgets)
   list(APPEND UNITTEST_LIBS Qt6::Core Qt6::Widgets)

--- a/tests/unittests/CMakeLists.txt
+++ b/tests/unittests/CMakeLists.txt
@@ -24,6 +24,7 @@ set(UNITTEST_SOURCES
   test_attribute_factory.cpp
   test_event.cpp
   test_container_group_sync.cpp
+  test_gradient_metrics.cpp
 )
 
 set(UNITTEST_LIBS

--- a/tests/unittests/CMakeLists.txt
+++ b/tests/unittests/CMakeLists.txt
@@ -25,6 +25,7 @@ set(UNITTEST_SOURCES
   test_event.cpp
   test_container_group_sync.cpp
   test_gradient_metrics.cpp
+  test_gradient_library.cpp
 )
 
 set(UNITTEST_LIBS

--- a/tests/unittests/test_gradient_library.cpp
+++ b/tests/unittests/test_gradient_library.cpp
@@ -1,0 +1,319 @@
+/* Copyright (c) 2026 Otto Link. Distributed under the terms of the GNU General
+   Public License. The full license is in the file LICENSE, distributed with
+   this software. */
+#include <filesystem>
+#include <fstream>
+
+#include <gtest/gtest.h>
+
+#include "meta.hpp"
+
+#ifdef META_ENABLE_COLOR_GRADIENT_TYPES
+
+#include "meta/ext/color_gradient/gradient_library.hpp"
+
+namespace {
+
+std::filesystem::path make_temp_dir(const std::string &tag) {
+  const auto dir =
+      std::filesystem::temp_directory_path() / ("meta_gradient_library_" + tag);
+  std::filesystem::remove_all(dir);
+  std::filesystem::create_directories(dir);
+  return dir;
+}
+
+meta::Preset make_preset(const std::string &name, float r, float g, float b) {
+  return {name, {{0.f, {0.f, 0.f, 0.f, 1.f}}, {1.f, {r, g, b, 1.f}}}};
+}
+
+} // namespace
+
+TEST(GradientLibraryTest, AddMakesNamesUnique) {
+  meta::GradientLibrary lib;
+
+  EXPECT_EQ(lib.add(make_preset("Fire", 1.f, 0.f, 0.f)), "Fire");
+  EXPECT_EQ(lib.add(make_preset("Fire", 0.f, 1.f, 0.f)), "Fire (2)");
+  EXPECT_EQ(lib.add(make_preset("  Fire  ", 0.f, 0.f, 1.f)), "Fire (3)");
+  EXPECT_EQ(lib.add(make_preset("", 0.f, 0.f, 1.f)), "Gradient");
+
+  EXPECT_EQ(lib.unique_name("Fire"), "Fire (4)");
+  EXPECT_EQ(lib.unique_name("Host", {"Host"}), "Host (2)");
+  EXPECT_EQ(lib.unique_name("Free"), "Free");
+
+  ASSERT_EQ(lib.presets().size(), 4u);
+  EXPECT_TRUE(lib.has("Fire (2)"));
+  EXPECT_FALSE(lib.has("Water"));
+}
+
+TEST(GradientLibraryTest, AddSortsStopsByPosition) {
+  meta::GradientLibrary lib;
+  lib.add({"Rev", {{1.f, {1.f, 1.f, 1.f, 1.f}}, {0.f, {0.f, 0.f, 0.f, 1.f}}}});
+
+  const meta::Preset *p = lib.find("Rev");
+  ASSERT_NE(p, nullptr);
+  EXPECT_FLOAT_EQ(p->stops.front().position, 0.f);
+  EXPECT_FLOAT_EQ(p->stops.back().position, 1.f);
+  EXPECT_EQ(lib.find("nope"), nullptr);
+}
+
+TEST(GradientLibraryTest, UpdateRenameRemove) {
+  meta::GradientLibrary lib;
+  lib.add(make_preset("A", 1.f, 0.f, 0.f));
+  lib.add(make_preset("B", 0.f, 1.f, 0.f));
+
+  const std::vector<meta::Stop> new_stops = {{0.f, {0.f, 0.f, 1.f, 1.f}},
+                                             {1.f, {1.f, 1.f, 0.f, 1.f}}};
+  EXPECT_TRUE(lib.update("A", new_stops));
+  EXPECT_EQ(lib.find("A")->stops, new_stops);
+  EXPECT_FALSE(lib.update("Zzz", new_stops));
+
+  EXPECT_FALSE(lib.rename("A", "B"));  // taken
+  EXPECT_FALSE(lib.rename("A", "  ")); // empty
+  EXPECT_FALSE(lib.rename("Zzz", "C"));
+  EXPECT_TRUE(lib.rename("A", "A")); // no-op
+  EXPECT_TRUE(lib.rename("A", " C "));
+  EXPECT_TRUE(lib.has("C"));
+  EXPECT_FALSE(lib.has("A"));
+
+  EXPECT_TRUE(lib.remove("C"));
+  EXPECT_FALSE(lib.remove("C"));
+  EXPECT_EQ(lib.presets().size(), 1u);
+
+  lib.clear();
+  EXPECT_TRUE(lib.presets().empty());
+}
+
+TEST(GradientLibraryTest, FavoritesFollowRenameAndRemoval) {
+  meta::GradientLibrary lib;
+  lib.add(make_preset("A", 1.f, 0.f, 0.f));
+
+  lib.set_favorite("A", true);
+  lib.set_favorite("Host preset", true); // not in the library: allowed
+  EXPECT_TRUE(lib.is_favorite("A"));
+  EXPECT_TRUE(lib.is_favorite("Host preset"));
+  EXPECT_EQ(lib.favorites().size(), 2u);
+
+  ASSERT_TRUE(lib.rename("A", "B"));
+  EXPECT_FALSE(lib.is_favorite("A"));
+  EXPECT_TRUE(lib.is_favorite("B"));
+
+  ASSERT_TRUE(lib.remove("B"));
+  EXPECT_FALSE(lib.is_favorite("B"));
+
+  lib.set_favorite("Host preset", false);
+  EXPECT_TRUE(lib.favorites().empty());
+}
+
+TEST(GradientLibraryTest, ChangedFiresOncePerEffectiveMutation) {
+  meta::GradientLibrary lib;
+  int count = 0;
+  auto conn = lib.changed.subscribe([&count]() { ++count; });
+
+  lib.add(make_preset("A", 1.f, 0.f, 0.f));
+  EXPECT_EQ(count, 1);
+  lib.set_favorite("A", true);
+  EXPECT_EQ(count, 2);
+  lib.set_favorite("A", true); // already a favourite
+  EXPECT_EQ(count, 2);
+  lib.set_sort(meta::GradientSort::Name);
+  EXPECT_EQ(count, 3);
+  lib.set_sort(meta::GradientSort::Name);
+  EXPECT_EQ(count, 3);
+  EXPECT_TRUE(lib.remove("A"));
+  EXPECT_EQ(count, 4);
+  EXPECT_FALSE(lib.remove("A"));
+  EXPECT_EQ(count, 4);
+}
+
+TEST(GradientLibraryTest, JsonRoundTrip) {
+  meta::GradientLibrary lib;
+  lib.add(make_preset("A", 1.f, 0.f, 0.f));
+  lib.add(make_preset("B", 0.f, 1.f, 0.f));
+  lib.set_favorite("B", true);
+  lib.set_sort(meta::GradientSort::Luminance);
+
+  const nlohmann::json j = lib.json_to();
+  EXPECT_EQ(j["format"], "meta.gradients");
+  EXPECT_EQ(j["version"], 1);
+  EXPECT_EQ(j["sort"], "luminance");
+  ASSERT_EQ(j["gradients"].size(), 2u);
+
+  meta::GradientLibrary copy;
+  ASSERT_TRUE(copy.json_from(j));
+  EXPECT_EQ(copy.presets(), lib.presets());
+  EXPECT_EQ(copy.favorites(), lib.favorites());
+  EXPECT_EQ(copy.sort(), meta::GradientSort::Luminance);
+
+  // invalid documents are rejected and leave the state untouched
+  EXPECT_FALSE(copy.json_from(nlohmann::json::array()));
+  EXPECT_FALSE(copy.json_from(nlohmann::json{{"foo", 1}}));
+  EXPECT_EQ(copy.presets().size(), 2u);
+
+  // an empty library document is valid
+  meta::GradientLibrary empty;
+  ASSERT_TRUE(empty.json_from(meta::GradientLibrary().json_to()));
+  EXPECT_TRUE(empty.presets().empty());
+}
+
+TEST(GradientLibraryTest, AutosaveAndLoad) {
+  const auto dir = make_temp_dir("autosave");
+  const auto file = dir / "nested" / "gradients.json";
+
+  {
+    meta::GradientLibrary lib;
+    lib.set_path(file);
+    EXPECT_EQ(lib.path(), file);
+    lib.add(make_preset("Saved", 1.f, 0.5f, 0.f));
+    lib.set_favorite("Saved", true);
+  }
+  ASSERT_TRUE(std::filesystem::exists(file));
+
+  meta::GradientLibrary loaded;
+  loaded.set_path(file);
+  ASSERT_TRUE(loaded.load());
+  ASSERT_EQ(loaded.presets().size(), 1u);
+  EXPECT_EQ(loaded.presets()[0].name, "Saved");
+  EXPECT_TRUE(loaded.is_favorite("Saved"));
+
+  meta::GradientLibrary missing;
+  missing.set_path(dir / "missing.json");
+  EXPECT_FALSE(missing.load());
+
+  meta::GradientLibrary no_path;
+  EXPECT_FALSE(no_path.save());
+  no_path.add(make_preset("Memory only", 0.f, 0.f, 1.f));
+  EXPECT_EQ(no_path.presets().size(), 1u);
+
+  meta::GradientLibrary manual;
+  manual.set_path(dir / "manual.json");
+  manual.set_autosave(false);
+  EXPECT_FALSE(manual.autosave());
+  manual.add(make_preset("Not yet", 0.f, 0.f, 1.f));
+  EXPECT_FALSE(std::filesystem::exists(dir / "manual.json"));
+  EXPECT_TRUE(manual.save());
+  EXPECT_TRUE(std::filesystem::exists(dir / "manual.json"));
+}
+
+TEST(GradientLibraryTest, CorruptFileLeavesStateUntouched) {
+  const auto dir = make_temp_dir("corrupt");
+
+  meta::GradientLibrary lib;
+  lib.add(make_preset("Keep", 1.f, 0.f, 0.f));
+
+  {
+    std::ofstream out(dir / "broken.json");
+    out << "{ not json";
+  }
+  lib.set_path(dir / "broken.json");
+  EXPECT_FALSE(lib.load());
+  EXPECT_EQ(lib.presets().size(), 1u);
+
+  {
+    std::ofstream out(dir / "no_gradients.json");
+    out << R"({"favorites": []})";
+  }
+  lib.set_path(dir / "no_gradients.json");
+  EXPECT_FALSE(lib.load());
+  EXPECT_EQ(lib.presets().size(), 1u);
+}
+
+TEST(GradientLibraryTest, ImportPolicy) {
+  const auto dir = make_temp_dir("import");
+
+  meta::GradientLibrary source;
+  source.add(make_preset("Same", 1.f, 0.f, 0.f));
+  source.add(make_preset("Conflict", 0.f, 1.f, 0.f));
+  source.add(make_preset("New", 0.f, 0.f, 1.f));
+  source.set_favorite("New", true);
+  ASSERT_TRUE(source.export_file(dir / "export.json", source.presets()));
+
+  nlohmann::json exported;
+  std::ifstream(dir / "export.json") >> exported;
+  EXPECT_FALSE(exported.contains("favorites"));
+  EXPECT_FALSE(exported.contains("sort"));
+  EXPECT_EQ(exported["format"], "meta.gradients");
+
+  meta::GradientLibrary lib;
+  lib.add(make_preset("Same", 1.f, 0.f, 0.f));
+  lib.add(make_preset("Conflict", 0.2f, 0.2f, 0.2f));
+
+  const auto report = lib.import_file(dir / "export.json");
+  EXPECT_TRUE(report.ok);
+  EXPECT_EQ(report.added, 1u);
+  EXPECT_EQ(report.renamed, 1u);
+  EXPECT_EQ(report.skipped, 1u);
+  EXPECT_TRUE(lib.has("New"));
+  EXPECT_TRUE(lib.has("Conflict (2)"));
+  EXPECT_EQ(lib.presets().size(), 4u);
+  EXPECT_FALSE(lib.is_favorite("New"));
+
+  EXPECT_FALSE(lib.import_file(dir / "nope.json").ok);
+  EXPECT_EQ(lib.presets().size(), 4u);
+}
+
+TEST(GradientLibraryTest, ParsesHesiodFileShapes) {
+  // Hesiod data/color_gradients/<stem>.json: Meta's ColorGradient::json_to
+  // shape, no name -> the fallback (file stem) is used
+  const auto per_file = nlohmann::json::parse(R"({
+    "label": "gradient", "type": 3,
+    "value": [
+      {"color": [0.1, 0.2, 0.3, 1.0], "position": 0.0},
+      {"color": [0.5, 0.6, 0.7, 1.0], "position": 1.0}
+    ]})");
+  auto parsed = meta::parse_gradient_file(per_file, "051c4a");
+  ASSERT_TRUE(parsed.has_value());
+  ASSERT_EQ(parsed->size(), 1u);
+  EXPECT_EQ((*parsed)[0].name, "051c4a");
+  EXPECT_NEAR((*parsed)[0].stops[1].color[2], 0.7f, 1e-6f);
+
+  // Hesiod data/color_gradient.json: collection with 0-255 colours
+  const auto collection = nlohmann::json::parse(R"({
+    "gradients": [
+      {"name": "Snow", "stops": [
+        {"position": 0.0, "color": [200, 220, 255, 255]},
+        {"position": 1.0, "color": [255, 255, 255, 255]}]}
+    ]})");
+  parsed = meta::parse_gradient_file(collection);
+  ASSERT_TRUE(parsed.has_value());
+  ASSERT_EQ(parsed->size(), 1u);
+  EXPECT_EQ((*parsed)[0].name, "Snow");
+  EXPECT_NEAR((*parsed)[0].stops[0].color[0], 200.f / 255.f, 1e-6f);
+  EXPECT_NEAR((*parsed)[0].stops[0].color[3], 1.f, 1e-6f);
+
+  // bare array without names -> numbered fallbacks; RGB gets alpha 1;
+  // unsorted stops are sorted
+  const auto bare = nlohmann::json::parse(R"([
+    {"stops": [{"position": 1.0, "color": [0, 0, 1]},
+               {"position": 0.0, "color": [1, 0, 0]}]},
+    {"stops": [{"position": 0.0, "color": [0, 1, 0]},
+               {"position": 1.0, "color": [0, 0, 0]}]}
+  ])");
+  parsed = meta::parse_gradient_file(bare, "Import");
+  ASSERT_TRUE(parsed.has_value());
+  ASSERT_EQ(parsed->size(), 2u);
+  EXPECT_EQ((*parsed)[0].name, "Import 1");
+  EXPECT_EQ((*parsed)[1].name, "Import 2");
+  EXPECT_FLOAT_EQ((*parsed)[0].stops[0].position, 0.f);
+  EXPECT_FLOAT_EQ((*parsed)[0].stops[0].color[0], 1.f);
+  EXPECT_FLOAT_EQ((*parsed)[0].stops[0].color[3], 1.f);
+
+  // entries with fewer than two valid stops are dropped; garbage is rejected
+  const auto degenerate = nlohmann::json::parse(
+      R"({"name": "x", "stops": [{"position": 0.0, "color": [1, 1, 1, 1]}]})");
+  EXPECT_FALSE(meta::parse_gradient_file(degenerate).has_value());
+  EXPECT_FALSE(meta::parse_gradient_file(nlohmann::json(42)).has_value());
+  EXPECT_FALSE(meta::parse_gradient_file(nlohmann::json::object()).has_value());
+}
+
+TEST(GradientLibraryTest, SortNamesRoundTrip) {
+  using meta::GradientSort;
+  for (GradientSort s : {GradientSort::Default, GradientSort::Name,
+                         GradientSort::Luminance, GradientSort::Hue}) {
+    const auto back = meta::gradient_sort_from_string(meta::to_string(s));
+    ASSERT_TRUE(back.has_value());
+    EXPECT_EQ(*back, s);
+  }
+  EXPECT_FALSE(meta::gradient_sort_from_string("bogus").has_value());
+}
+
+#endif // META_ENABLE_COLOR_GRADIENT_TYPES

--- a/tests/unittests/test_gradient_metrics.cpp
+++ b/tests/unittests/test_gradient_metrics.cpp
@@ -1,0 +1,103 @@
+/* Copyright (c) 2026 Otto Link. Distributed under the terms of the GNU General
+   Public License. The full license is in the file LICENSE, distributed with
+   this software. */
+#include <gtest/gtest.h>
+
+#include "meta.hpp"
+
+#ifdef META_ENABLE_COLOR_GRADIENT_TYPES
+
+#include "meta/ext/color_gradient/gradient_metrics.hpp"
+
+namespace {
+
+meta::Stop stop(float t, float r, float g, float b, float a = 1.f) {
+  return {t, {r, g, b, a}};
+}
+
+} // namespace
+
+TEST(GradientMetricsTest, StopAndPresetEquality) {
+  const meta::Preset a{"x",
+                       {stop(0.f, 0.f, 0.f, 0.f), stop(1.f, 1.f, 1.f, 1.f)}};
+  meta::Preset b = a;
+  EXPECT_EQ(a, b);
+  b.stops[1].color[0] = 0.5f;
+  EXPECT_NE(a, b);
+  b = a;
+  b.name = "y";
+  EXPECT_NE(a, b);
+}
+
+TEST(GradientMetricsTest, SampleInterpolatesAndClamps) {
+  // deliberately unsorted
+  const std::vector<meta::Stop> stops = {stop(1.f, 1.f, 1.f, 1.f, 1.f),
+                                         stop(0.f, 0.f, 0.f, 0.f, 0.f)};
+
+  const auto mid = meta::sample_gradient(stops, 0.5f);
+  for (int k = 0; k < 4; ++k)
+    EXPECT_NEAR(mid[k], 0.5f, 1e-5f);
+
+  EXPECT_FLOAT_EQ(meta::sample_gradient(stops, -1.f)[0], 0.f);
+  EXPECT_FLOAT_EQ(meta::sample_gradient(stops, 2.f)[0], 1.f);
+
+  const auto empty = meta::sample_gradient({}, 0.3f);
+  EXPECT_FLOAT_EQ(empty[0], 0.f);
+  EXPECT_FLOAT_EQ(empty[3], 1.f);
+}
+
+TEST(GradientMetricsTest, SampleHoldsEndColorsOutsideStopRange) {
+  const std::vector<meta::Stop> stops = {stop(0.25f, 1.f, 0.f, 0.f),
+                                         stop(0.75f, 0.f, 0.f, 1.f)};
+  EXPECT_FLOAT_EQ(meta::sample_gradient(stops, 0.1f)[0], 1.f);
+  EXPECT_FLOAT_EQ(meta::sample_gradient(stops, 0.9f)[2], 1.f);
+  EXPECT_NEAR(meta::sample_gradient(stops, 0.5f)[0], 0.5f, 1e-5f);
+}
+
+TEST(GradientMetricsTest, LuminanceOrdersDarkToLight) {
+  const std::vector<meta::Stop> black = {stop(0.f, 0.f, 0.f, 0.f),
+                                         stop(1.f, 0.f, 0.f, 0.f)};
+  const std::vector<meta::Stop> grey = {stop(0.f, 0.5f, 0.5f, 0.5f),
+                                        stop(1.f, 0.5f, 0.5f, 0.5f)};
+  const std::vector<meta::Stop> white = {stop(0.f, 1.f, 1.f, 1.f),
+                                         stop(1.f, 1.f, 1.f, 1.f)};
+  const std::vector<meta::Stop> ramp = {stop(0.f, 0.f, 0.f, 0.f),
+                                        stop(1.f, 1.f, 1.f, 1.f)};
+
+  EXPECT_LT(meta::gradient_luminance(black), meta::gradient_luminance(grey));
+  EXPECT_LT(meta::gradient_luminance(grey), meta::gradient_luminance(white));
+  EXPECT_NEAR(meta::gradient_luminance(white), 1.f, 1e-5f);
+  EXPECT_NEAR(meta::gradient_luminance(ramp), 0.5f, 0.02f);
+  EXPECT_FLOAT_EQ(meta::gradient_luminance({}), 0.f);
+}
+
+TEST(GradientMetricsTest, HueOfPrimaries) {
+  const std::vector<meta::Stop> red = {stop(0.f, 1.f, 0.f, 0.f),
+                                       stop(1.f, 1.f, 0.f, 0.f)};
+  const std::vector<meta::Stop> green = {stop(0.f, 0.f, 1.f, 0.f),
+                                         stop(1.f, 0.f, 1.f, 0.f)};
+  const std::vector<meta::Stop> blue = {stop(0.f, 0.f, 0.f, 1.f),
+                                        stop(1.f, 0.f, 0.f, 1.f)};
+
+  const float h_red = meta::gradient_hue(red);
+  EXPECT_TRUE(h_red < 1.f || h_red > 359.f) << h_red;
+  EXPECT_NEAR(meta::gradient_hue(green), 120.f, 0.5f);
+  EXPECT_NEAR(meta::gradient_hue(blue), 240.f, 0.5f);
+}
+
+TEST(GradientMetricsTest, HueAveragesAcrossWrapAround) {
+  // 350 deg -> 10 deg through red: the circular mean sits near 0, not 180
+  const std::vector<meta::Stop> stops = {stop(0.f, 1.f, 0.f, 1.f / 6.f),
+                                         stop(1.f, 1.f, 1.f / 6.f, 0.f)};
+  const float h = meta::gradient_hue(stops);
+  EXPECT_TRUE(h < 5.f || h > 355.f) << h;
+}
+
+TEST(GradientMetricsTest, AchromaticGradientHasNoHue) {
+  const std::vector<meta::Stop> ramp = {stop(0.f, 0.f, 0.f, 0.f),
+                                        stop(1.f, 1.f, 1.f, 1.f)};
+  EXPECT_FLOAT_EQ(meta::gradient_hue(ramp), -1.f);
+  EXPECT_FLOAT_EQ(meta::gradient_hue({}), -1.f);
+}
+
+#endif // META_ENABLE_COLOR_GRADIENT_TYPES

--- a/tests/unittests/test_gradient_picker.cpp
+++ b/tests/unittests/test_gradient_picker.cpp
@@ -1,0 +1,166 @@
+/* Copyright (c) 2026 Otto Link. Distributed under the terms of the GNU General
+   Public License. The full license is in the file LICENSE, distributed with
+   this software. */
+#include <filesystem>
+
+#include <gtest/gtest.h>
+
+#include "meta.hpp"
+
+#ifdef META_ENABLE_COLOR_GRADIENT_TYPES
+
+#include <QCoreApplication>
+#include <QPushButton>
+
+#include "meta/ext/color_gradient/gradient_library.hpp"
+#include "meta_qt/widgets/gradient_picker.hpp"
+
+namespace {
+
+std::vector<meta::Preset> host_presets() {
+  return {
+      {"Host B", {{0.f, {0.f, 0.f, 0.f, 1.f}}, {1.f, {1.f, 0.f, 0.f, 1.f}}}},
+      {"Host A", {{0.f, {0.f, 0.f, 0.f, 1.f}}, {1.f, {0.f, 0.f, 1.f, 1.f}}}}};
+}
+
+meta::Preset lib_preset(const std::string &name) {
+  return {name, {{0.f, {0.f, 0.f, 0.f, 1.f}}, {1.f, {0.f, 1.f, 0.f, 1.f}}}};
+}
+
+// Points the process-wide library at a scratch file and empties it, so the
+// tests never touch a real per-user library.
+struct IsolatedLibrary {
+  IsolatedLibrary() {
+    const auto dir =
+        std::filesystem::temp_directory_path() / "meta_gradient_picker_test";
+    std::filesystem::remove_all(dir);
+
+    auto &lib = meta::GradientLibrary::instance();
+    lib.set_path(dir / "gradients.json");
+    lib.clear();
+    lib.set_sort(meta::GradientSort::Default);
+  }
+
+  ~IsolatedLibrary() {
+    auto &lib = meta::GradientLibrary::instance();
+    lib.clear();
+    lib.set_sort(meta::GradientSort::Default);
+  }
+};
+
+// Library notifications rebuild the grid through a queued call.
+void flush() {
+  QCoreApplication::sendPostedEvents();
+  QCoreApplication::processEvents();
+}
+
+int swatch_count(const meta::qt::GradientPicker &picker) {
+  return static_cast<int>(picker.findChildren<QPushButton *>().size());
+}
+
+} // namespace
+
+TEST(GradientPickerTest, MergesHostAndLibraryPresets) {
+  IsolatedLibrary isolated;
+  meta::GradientLibrary::instance().add(lib_preset("Lib"));
+
+  std::vector<meta::Stop> stops = {{0.f, {0.f, 0.f, 0.f, 1.f}},
+                                   {1.f, {1.f, 1.f, 1.f, 1.f}}};
+  meta::qt::GradientPicker picker(stops, host_presets());
+
+  EXPECT_EQ(picker.entry_names(),
+            (std::vector<std::string>{"Host B", "Host A", "Lib"}));
+  EXPECT_EQ(swatch_count(picker), 3);
+
+  int user_count = 0;
+  for (auto *button : picker.findChildren<QPushButton *>())
+    if (button->property("preset_user").toBool())
+      ++user_count;
+  EXPECT_EQ(user_count, 1);
+}
+
+TEST(GradientPickerTest, FavoritesPinnedFirstThenSortKey) {
+  IsolatedLibrary isolated;
+  auto &lib = meta::GradientLibrary::instance();
+  lib.add(lib_preset("Lib"));
+
+  std::vector<meta::Stop> stops = {{0.f, {0.f, 0.f, 0.f, 1.f}},
+                                   {1.f, {1.f, 1.f, 1.f, 1.f}}};
+  meta::qt::GradientPicker picker(stops, host_presets());
+
+  lib.set_favorite("Lib", true);
+  flush();
+  EXPECT_EQ(picker.entry_names(),
+            (std::vector<std::string>{"Lib", "Host B", "Host A"}));
+
+  lib.set_sort(meta::GradientSort::Name);
+  flush();
+  EXPECT_EQ(picker.entry_names(),
+            (std::vector<std::string>{"Lib", "Host A", "Host B"}));
+
+  lib.set_favorite("Lib", false);
+  flush();
+  EXPECT_EQ(picker.entry_names(),
+            (std::vector<std::string>{"Host A", "Host B", "Lib"}));
+}
+
+TEST(GradientPickerTest, LuminanceSortGoesDarkToLight) {
+  IsolatedLibrary isolated;
+  auto &lib = meta::GradientLibrary::instance();
+  lib.add(
+      {"Bright", {{0.f, {1.f, 1.f, 1.f, 1.f}}, {1.f, {1.f, 1.f, 1.f, 1.f}}}});
+  lib.add(
+      {"Dark", {{0.f, {0.f, 0.f, 0.f, 1.f}}, {1.f, {0.1f, 0.1f, 0.1f, 1.f}}}});
+  lib.set_sort(meta::GradientSort::Luminance);
+
+  std::vector<meta::Stop> stops = {{0.f, {0.f, 0.f, 0.f, 1.f}},
+                                   {1.f, {1.f, 1.f, 1.f, 1.f}}};
+  meta::qt::GradientPicker picker(stops, {});
+
+  EXPECT_EQ(picker.entry_names(), (std::vector<std::string>{"Dark", "Bright"}));
+}
+
+TEST(GradientPickerTest, SaveCurrentAsPresetAvoidsHostNames) {
+  IsolatedLibrary isolated;
+  auto &lib = meta::GradientLibrary::instance();
+
+  std::vector<meta::Stop> stops = {{1.f, {1.f, 1.f, 0.f, 1.f}},
+                                   {0.f, {0.f, 0.f, 0.f, 1.f}}};
+  meta::qt::GradientPicker picker(stops, host_presets());
+
+  EXPECT_EQ(picker.save_current_as_preset("Mine"), "Mine");
+  EXPECT_EQ(picker.save_current_as_preset("Mine"), "Mine (2)");
+  EXPECT_EQ(picker.save_current_as_preset("Host A"), "Host A (2)");
+
+  const meta::Preset *saved = lib.find("Mine");
+  ASSERT_NE(saved, nullptr);
+  ASSERT_EQ(saved->stops.size(), 2u);
+  EXPECT_FLOAT_EQ(saved->stops[0].position, 0.f); // stored sorted
+  EXPECT_FLOAT_EQ(saved->stops[1].color[0], 1.f);
+
+  flush();
+  EXPECT_EQ(picker.entry_names().size(), 5u);
+  EXPECT_EQ(swatch_count(picker), 5);
+}
+
+TEST(GradientPickerTest, LibraryChangesRebuildTheGrid) {
+  IsolatedLibrary isolated;
+  auto &lib = meta::GradientLibrary::instance();
+
+  std::vector<meta::Stop> stops = {{0.f, {0.f, 0.f, 0.f, 1.f}},
+                                   {1.f, {1.f, 1.f, 1.f, 1.f}}};
+  meta::qt::GradientPicker picker(stops, host_presets());
+  EXPECT_EQ(swatch_count(picker), 2);
+
+  lib.add(lib_preset("One"));
+  lib.add(lib_preset("Two"));
+  flush();
+  EXPECT_EQ(swatch_count(picker), 4);
+
+  ASSERT_TRUE(lib.remove("One"));
+  flush();
+  EXPECT_EQ(swatch_count(picker), 3);
+  EXPECT_EQ(picker.entry_names().back(), "Two");
+}
+
+#endif // META_ENABLE_COLOR_GRADIENT_TYPES


### PR DESCRIPTION
Closes #50.

Makes user-made gradients reusable across projects and easy to organise and share, on both sides of the Meta/Qt split.

**Core (`Meta/ext/color_gradient`).** `GradientLibrary` holds the user's presets, favourite names and preferred ordering, autosaves them to a JSON file and notifies an `Event<> changed` on every effective mutation. `GradientLibrary::instance()` is the process-wide default (same pattern as `AttributeFactory` / `DesignRegistry`); the class stays instantiable for tests. Import merges without prompting: identical duplicates are skipped, clashing names get a `" (2)"` suffix. The reader is tolerant on purpose: it takes the `{"gradients": [...]}` document, a bare array, or a single gradient object, stops under `"stops"` or `"value"` (the `ColorGradient::json_to()` shape) and 0–255 colours, so Hesiod's `data/color_gradients/*.json` and `data/color_gradient.json` import as-is. `gradient_metrics.hpp` adds sampling, mean luminance and a saturation-weighted circular hue for the sort keys.

**Qt (`GradientPicker`).** The grid now merges the host presets from metadata with the library. A toolbar row offers Save… (current gradient → library), Import…, Export… and a Sort combo (Default / Name / Luminance / Hue, persisted). Favourites are starred and always pinned first; library entries carry a small dot. Right-click on a swatch: add/remove favourite, and for library entries rename, replace with the current gradient, delete, plus export of a single gradient. Library notifications rebuild the grid through a queued call so a picker never deletes the very button whose slot is running, and bursts (imports) coalesce.

**Where the file lives.** On first use the picker sets `QStandardPaths::AppConfigLocation/gradients.json` (fallback `AppDataLocation`) unless the host already called `set_path()` + `load()`. Hesiod builds unchanged (the picker constructor is the same), but a one-liner at startup could co-locate the file with `hesiod.json`.

**Decisions worth a look** (all easy to change): favourites are keyed by preset name and may point at host presets; favourites always sort first; imports never prompt; exports carry gradients only, never favourites; the Save dialog auto-suffixes a taken name instead of asking to overwrite (overwrite is the context menu's "Replace with current gradient").

**Tests.** 23 new GoogleTest cases (`test_gradient_metrics`, `test_gradient_library`, `test_gradient_picker`, the last one offscreen against an isolated library file); 57 total pass with `-DMETA_ENABLE_UNITTESTS=ON -DMETA_ENABLE_QT_UI=ON`. `tests/test_qt/gradient_picker_snap` renders the widget per sort key to PNG for eyeballing, like `rangebar_snap`; `test_meta_qt` now points the library at a temp file so manual runs stay clean.
